### PR TITLE
(#69) Remove stamp of CCMVersion TeamCity parameter

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/gitversion.cake
+++ b/Chocolatey.Cake.Recipe/Content/gitversion.cake
@@ -219,12 +219,6 @@ public class BuildVersion
         {
             // use the asserted package version for the build number in TeamCity
             context.BuildSystem().TeamCity.SetBuildNumber(packageVersion);
-
-            if (BuildParameters.Title == "ChocolateySoftware.ChocolateyManagement")
-            {
-                // Only set this when it is a CCM Build
-                context.BuildSystem().TeamCity.SetParameter("CCMVersion", packageVersion);
-            }
         }
 
         return new BuildVersion


### PR DESCRIPTION
## Description Of Changes

Remove the stamping of the CCMVersion parameter as it is no longer needed.

## Motivation and Context

We already set the `build.number` parameter that can be used in build chaining in TeamCity. This was also a special case to set the parameter only for CCM builds.

## Testing

I haven't tested this at all. I have however tested that I can use `build.number` in dependency build chaining in TeamCity

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [c] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #69

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
