### PR TITLE
(#74) Update prerelease tag if starts with digit

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/gitversion.cake
+++ b/Chocolatey.Cake.Recipe/Content/gitversion.cake
@@ -124,6 +124,13 @@ public class BuildVersion
             prerelease = prerelease.Replace("-", string.Empty).Substring(0, 10);
         }
 
+        // Chocolatey doesn't support a prerelease that starts with a digit.
+        // If we see a digit here, merely replace it with an `a` to get around this.
+        if (System.Text.RegularExpressions.Regex.Match(prerelease, @"^\d.*$").Success)
+        {
+            prerelease = string.Format("a{0}", prerelease.Substring(1,9));
+        }
+
         sha = assertedVersions.Sha.Substring(0,8);
 
         if (context.FileExists(preReleaseLabelFilePath))


### PR DESCRIPTION
## Description Of Changes

Update the prerelease tag to start with an `a` if it starts with a digit.

## Motivation and Context

Chocolatey doesn't allow prerelease tags that start with a digit.

## Testing

1. Ran `./build.bat`
2. Copied generated nupkg contents into `ChocolateyGUI` project
3. Ran `./build.bat -Target Print-CI-Provider-Environment-Variables` to verify that version number prints properly.

## Change Types Made

* [x] Bug fix (non-breaking change)
* [ ] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #74

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.