### PR TITLE
(#80) Add support for building/deploying AWS Lambdas

### DIFF
--- a/Chocolatey.Cake.Recipe/Chocolatey.Cake.Recipe.nuspec
+++ b/Chocolatey.Cake.Recipe/Chocolatey.Cake.Recipe.nuspec
@@ -7,7 +7,7 @@
     <owners>Chocolatey Software, Inc.</owners>
     <summary>Opinionated set of scripts for use with Cake Builds for Chocolatey products.</summary>
     <description>
-This NuGet package contains a set of re-usable scripts that is intended for use to build Chocolatey products by adding a single load pre-processor directive to your main Cake Script.  As a result, it is possible to use the same set of build scripts across multiple projects, without having to duplicate the scripts.  All that is required is a small recipe build script, which sets the project specific information.  It is not intneded that the scripts within this package will be usable by everyone, as there will be decisions/conventions that are specific to how we build things at Chocolatey Software, Inc.
+This NuGet package contains a set of re-usable scripts that is intended for use to build Chocolatey products by adding a single load pre-processor directive to your main Cake Script.  As a result, it is possible to use the same set of build scripts across multiple projects, without having to duplicate the scripts.  All that is required is a small recipe build script, which sets the project specific information.  It is not intended that the scripts within this package will be usable by everyone, as there will be decisions/conventions that are specific to how we build things at Chocolatey Software, Inc.
     </description>
     <copyright>2022-Present Chocolatey Software, Inc.</copyright>
     <iconUrl>https://chocolatey.org/assets/images/nupkg/chocolateyicon.png</iconUrl>

--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -261,11 +261,9 @@ public void CopyBuildOutput()
             var projectDirectoryPath = project.Path.GetDirectory();
             var packageOutputFilePath = outputFolder.Combine(parsedProject.AssemblyName + "." + BuildParameters.Version.PackageVersion + ".zip");
 
-            DotNetCoreTool(
-                null,
-                "lambda",
-                string.Format("package --project-location {0} --configuration {1} --output-package {2}", projectDirectoryPath, BuildParameters.Configuration, packageOutputFilePath)
-            );
+            RequireTool(ToolSettings.AmazonLambdaGlobalTool, () => {
+                StartProcess("./tools/dotnet-lambda.exe", new ProcessSettings { Arguments = string.Format("package --project-location {0} --configuration {1} --output-package {2}", projectDirectoryPath, BuildParameters.Configuration, packageOutputFilePath) });
+            });
 
             if (FileExists(packageOutputFilePath.FullPath))
             {

--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -231,6 +231,13 @@ public void CopyBuildOutput()
             Information("IsGlobalTool: {0}", parsedProject.IsGlobalTool());
         }
 
+        var isAwsLambdaProject = false;
+
+        if (parsedProject.IsLibrary() && parsedProject.HasPackage("Amazon.Lambda.Core"))
+        {
+            isAwsLambdaProject = true;
+        }
+
         Information("IsDotNetCliTestProject: {0}", parsedProject.IsDotNetCliTestProject());
         Information("IsNetCore: {0}", parsedProject.IsNetCore);
         Information("IsNetStandard: {0}", parsedProject.IsNetStandard);
@@ -241,6 +248,32 @@ public void CopyBuildOutput()
         Information("IXUnitTestProject: {0}", parsedProject.IsXUnitTestProject());
         Information("IsNUnitTestProject: {0}", parsedProject.IsNUnitTestProject());
         Information("IsWebApplication: {0}", parsedProject.IsWebApplication());
+        Information("IsAwsLambdaProject: {0}", isAwsLambdaProject);
+
+        if (isAwsLambdaProject && !(parsedProject.IsXUnitTestProject() || parsedProject.IsNUnitTestProject()))
+        {
+            Information("Project is an AWS Lambda Function Application: {0}", parsedProject.AssemblyName);
+
+            var outputFolder = MakeAbsolute(BuildParameters.Paths.Directories.PublishedLambdas.Combine(parsedProject.AssemblyName));
+
+            EnsureDirectoryExists(outputFolder);
+
+            var projectDirectoryPath = project.Path.GetDirectory();
+            var packageOutputFilePath = outputFolder.Combine(parsedProject.AssemblyName + "." + BuildParameters.Version.PackageVersion + ".zip");
+
+            DotNetCoreTool(
+                null,
+                "lambda",
+                string.Format("package --project-location {0} --configuration {1} --output-package {2}", projectDirectoryPath, BuildParameters.Configuration, packageOutputFilePath)
+            );
+
+            if (FileExists(packageOutputFilePath.FullPath))
+            {
+                BuildParameters.BuildProvider.UploadArtifact(packageOutputFilePath.FullPath);
+            }
+
+            continue;
+        }
 
         if (parsedProject.IsWebApplication() && parsedProject.IsNetFramework)
         {
@@ -424,6 +457,7 @@ BuildParameters.Tasks.DefaultTask = Task("Default")
 BuildParameters.Tasks.ContinuousIntegrationTask = Task("CI")
     .IsDependentOn("Publish-PreRelease-Packages")
     .IsDependentOn("Publish-Release-Packages")
+    .IsDependentOn("Publish-AWS-Lambdas")
     .IsDependentOn("Publish-GitHub-Release")
     .Finally(() =>
 {

--- a/Chocolatey.Cake.Recipe/Content/packages.cake
+++ b/Chocolatey.Cake.Recipe/Content/packages.cake
@@ -184,6 +184,44 @@ BuildParameters.Tasks.PublishReleasePackagesTask = Task("Publish-Release-Package
     publishingError = true;
 });
 
+BuildParameters.Tasks.PublishAwsLambdasTask = Task("Publish-AWS-Lambdas")
+    .WithCriteria(() => BuildParameters.ShouldPublishAwsLambdas, "Skipping because publishing of AWS Lambdas is not enabled")
+    .WithCriteria(() => !BuildParameters.IsLocalBuild || BuildParameters.ForceContinuousIntegration, "Skipping because this is a local build, and force isn't being applied")
+    .WithCriteria(() => !BuildParameters.IsPullRequest, "Skipping because current build is from a Pull Request")
+    .WithCriteria(() => BuildParameters.IsTagged, "Skipping because current commit is not tagged")
+    .IsDependentOn("DotNetBuild")
+    .Does(() =>
+{
+    if (DirectoryExists(BuildParameters.Paths.Directories.PublishedLambdas))
+    {
+        var lambdaPackages = GetFiles(BuildParameters.Paths.Directories.PublishedLambdas + "/**/*.zip");
+
+        foreach (var lambdaPackage in lambdaPackages)
+        {
+            Information("Deploying Lambda package from zip file: {0}", lambdaPackage);
+
+            var functionName = lambdaPackage.GetFilenameWithoutExtension().FullPath.ToLower();
+
+            // deploy the lambda...
+            DotNetCoreTool(
+                null,
+                "lambda",
+                string.Format("deploy-function --package-type zip --package {0} --disable-interactive true --function-name {1}-test", lambdaPackage, functionName)
+            );
+        }
+    }
+    else
+    {
+        Information("Unable to publish AWS Lambdas as AWS Lambdas Directory doesn't exist.");
+    }
+})
+.OnError(exception =>
+{
+    Error(exception.Message);
+    Information("Publish-AWS-Lambdas Task failed, but continuing with next Task...");
+    publishingError = true;
+});
+
 public void PushChocolateyPackages(ICakeContext context, bool isRelease, List<PackageSourceData> chocolateySources)
 {
     if (BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows && DirectoryExists(BuildParameters.Paths.Directories.ChocolateyPackages))

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -71,6 +71,7 @@ public static class BuildParameters
     public static bool ShouldDownloadMilestoneReleaseNotes { get; private set; }
     public static bool ShouldGenerateSolutionVersionCSharpFile { get; private set; }
     public static bool ShouldObfuscateOutputAssemblies { get; private set; }
+    public static bool ShouldPublishAwsLambdas { get; private set; }
     public static bool ShouldPublishPreReleasePackages { get; private set; }
     public static bool ShouldPublishReleasePackages { get; private set; }
     public static bool ShouldReportCodeCoverageMetrics { get; private set; }
@@ -179,6 +180,7 @@ public static class BuildParameters
         context.Information("ShouldDownloadMilestoneReleaseNotes: {0}", BuildParameters.ShouldDownloadMilestoneReleaseNotes);
         context.Information("ShouldGenerateSolutionVersionCSharpFile: {0}", BuildParameters.ShouldGenerateSolutionVersionCSharpFile);
         context.Information("ShouldObfuscateOutputAssemblies: {0}", BuildParameters.ShouldObfuscateOutputAssemblies);
+        context.Information("ShouldPublishAwsLambdas: {0}", BuildParameters.ShouldPublishAwsLambdas);
         context.Information("ShouldPublishPreReleasePackages: {0}", BuildParameters.ShouldPublishPreReleasePackages);
         context.Information("ShouldPublishReleasePackages: {0}", BuildParameters.ShouldPublishReleasePackages);
         context.Information("ShouldReportCodeCoverageMetrics: {0}", BuildParameters.ShouldReportCodeCoverageMetrics);
@@ -264,6 +266,7 @@ public static class BuildParameters
         bool shouldDownloadMilestoneReleaseNotes = false,
         bool shouldGenerateSolutionVersionCSharpFile = true,
         bool shouldObfuscateOutputAssemblies = true,
+        bool shouldPublishAwsLambdas = true,
         bool shouldPublishPreReleasePackages = true,
         bool shouldPublishReleasePackages = true,
         bool shouldReportCodeCoverageMetrics = true,
@@ -375,6 +378,7 @@ public static class BuildParameters
         ShouldDownloadMilestoneReleaseNotes = shouldDownloadMilestoneReleaseNotes;
         ShouldGenerateSolutionVersionCSharpFile = shouldGenerateSolutionVersionCSharpFile;
         ShouldObfuscateOutputAssemblies = shouldObfuscateOutputAssemblies;
+        ShouldPublishAwsLambdas = shouldPublishAwsLambdas;
         ShouldPublishPreReleasePackages = shouldPublishPreReleasePackages;
         ShouldPublishReleasePackages = shouldPublishReleasePackages;
         ShouldReportCodeCoverageMetrics = shouldReportCodeCoverageMetrics;

--- a/Chocolatey.Cake.Recipe/Content/paths.cake
+++ b/Chocolatey.Cake.Recipe/Content/paths.cake
@@ -13,6 +13,7 @@ public class BuildPaths
         var publishedWebsitesDirectory     = tempBuildDirectoryPath + "/_PublishedWebsites";
         var publishedApplicationsDirectory = tempBuildDirectoryPath + "/_PublishedApps";
         var publishedLibrariesDirectory    = tempBuildDirectoryPath + "/_PublishedLibs";
+        var publishedLambdasDirectory      = tempBuildDirectoryPath + "/_PublishedLambdas";
         var tempNuspecDirectory            = tempBuildDirectoryPath + "/nuspec";
         var publishedDocumentationDirectory= buildDirectoryPath + "/Documentation";
         var environmentSettingsDirectory   = "./settings";
@@ -49,6 +50,7 @@ public class BuildPaths
             publishedWebsitesDirectory,
             publishedApplicationsDirectory,
             publishedLibrariesDirectory,
+            publishedLambdasDirectory,
             chocolateyNuspecDirectory,
             nugetNuspecDirectory,
             testResultsDirectory,
@@ -122,6 +124,7 @@ public class BuildDirectories
     public DirectoryPath PublishedWebsites { get; private set; }
     public DirectoryPath PublishedApplications { get; private set; }
     public DirectoryPath PublishedLibraries { get; private set; }
+    public DirectoryPath PublishedLambdas { get; private set; }
     public DirectoryPath PublishedDocumentation { get; private set; }
     public DirectoryPath ChocolateyNuspecDirectory { get; private set; }
     public DirectoryPath NuGetNuspecDirectory { get; private set; }
@@ -144,6 +147,7 @@ public class BuildDirectories
         DirectoryPath publishedWebsites,
         DirectoryPath publishedApplications,
         DirectoryPath publishedLibraries,
+        DirectoryPath publishedLambdas,
         DirectoryPath chocolateyNuspecDirectory,
         DirectoryPath nugetNuspecDirectory,
         DirectoryPath testResults,
@@ -164,6 +168,7 @@ public class BuildDirectories
         PublishedWebsites = publishedWebsites;
         PublishedApplications = publishedApplications;
         PublishedLibraries = publishedLibraries;
+        PublishedLambdas = publishedLambdas;
         ChocolateyNuspecDirectory = chocolateyNuspecDirectory;
         NuGetNuspecDirectory = nugetNuspecDirectory;
         TestResults = testResults;

--- a/Chocolatey.Cake.Recipe/Content/tasks.cake
+++ b/Chocolatey.Cake.Recipe/Content/tasks.cake
@@ -33,6 +33,7 @@ public class BuildTasks
     public CakeTaskBuilder DotNetPackTask { get; set; }
     public CakeTaskBuilder PublishPreReleasePackagesTask { get; set; }
     public CakeTaskBuilder PublishReleasePackagesTask { get; set; }
+    public CakeTaskBuilder PublishAwsLambdasTask { get; set; }
 
     // Testing Tasks
     public CakeTaskBuilder InstallOpenCoverTask { get; set; }

--- a/Chocolatey.Cake.Recipe/Content/toolsettings.cake
+++ b/Chocolatey.Cake.Recipe/Content/toolsettings.cake
@@ -8,6 +8,7 @@ public static class ToolSettings
     public static MSBuildToolVersion BuildMSBuildToolVersion { get; private set; }
     public static PlatformTarget BuildPlatformTarget { get; private set; }
     public static FilePath EazfuscatorToolLocation { get; private set; }
+    public static string AmazonLambdaGlobalTool { get; private set; }
     public static string GitVersionGlobalTool { get; private set; }
     public static string GitVersionTool { get; private set; }
     public static string GitReleaseManagerGlobalTool { get; private set; }
@@ -30,6 +31,7 @@ public static class ToolSettings
     public static string XUnitTool { get; private set; }
 
     public static void SetToolPreprocessorDirectives(
+        string amazonLambdaGlobalTool = "#tool dotnet:?package=amazon.lambda.tools&version=5.4.5",
         string gitVersionGlobalTool = "#tool dotnet:?package=GitVersion.Tool&version=5.10.1",
         string gitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=5.10.1",
         string gitReleaseManagerGlobalTool = "#tool dotnet:?package=GitReleaseManager.Tool&version=0.13.0",
@@ -47,6 +49,7 @@ public static class ToolSettings
         string xunitTool = "#tool nuget:?package=xunit.runner.console&version=2.4.1"
     )
     {
+        AmazonLambdaGlobalTool = amazonLambdaGlobalTool;
         GitVersionGlobalTool = gitVersionGlobalTool;
         GitVersionTool = gitVersionTool;
         GitReleaseManagerGlobalTool = gitReleaseManagerGlobalTool;


### PR DESCRIPTION
## Description Of Changes

Adds support for both building/deploying AWS Lambda projects into Chocolatey.Cake.Recipe.

## Motivation and Context

Going forward, a number of infrastructure items are slated to be moved to AWS Lambdas, so it makes sense to have 1st class support for these project types within Chocolatey.Cake.Recipe.

## Testing

The new tasks have been executed locally, and we (myself and @JPRuskin) have proved that the zip file is created in the `_PublishedLambdas` folder, and also that the zip file is deployed correctly to the test AWS instance.

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #80

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.