### PR TITLE
(#93) Add support for resolving VS with VSWhere

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -125,7 +125,10 @@ BuildParameters.Tasks.BuildTask = Task("Build")
 
         if (BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows)
         {
-            var msbuildSettings = new MSBuildSettings()
+            var msbuildSettings = new MSBuildSettings
+            {
+                ToolPath = ToolSettings.MSBuildToolPath
+            }
                 .SetPlatformTarget(ToolSettings.BuildPlatformTarget)
                 .UseToolVersion(ToolSettings.BuildMSBuildToolVersion)
                 .WithProperty("TreatWarningsAsErrors", BuildParameters.TreatWarningsAsErrors.ToString())
@@ -298,7 +301,10 @@ public void CopyBuildOutput()
 
             EnsureDirectoryExists(outputFolder);
 
-            var msbuildSettings = new MSBuildSettings()
+            var msbuildSettings = new MSBuildSettings
+            {
+                ToolPath = ToolSettings.MSBuildToolPath
+            }
                 .SetPlatformTarget(ToolSettings.BuildPlatformTarget)
                 .UseToolVersion(ToolSettings.BuildMSBuildToolVersion)
                 .WithProperty("TreatWarningsAsErrors", BuildParameters.TreatWarningsAsErrors.ToString())
@@ -447,7 +453,10 @@ BuildParameters.Tasks.BuildMsiTask = Task("Build-MSI")
     .Does(() => RequireTool(ToolSettings.MSBuildExtensionPackTool, () => {
         Information("Building MSI from the following solution: {0}", BuildParameters.SolutionFilePath);
 
-        var msbuildSettings = new MSBuildSettings()
+        var msbuildSettings = new MSBuildSettings
+        {
+            ToolPath = ToolSettings.MSBuildToolPath
+        }
                 .SetPlatformTarget(PlatformTarget.x86)
                 .UseToolVersion(ToolSettings.BuildMSBuildToolVersion)
                 .WithProperty("TreatWarningsAsErrors", BuildParameters.TreatWarningsAsErrors.ToString())


### PR DESCRIPTION
## Description Of Changes

This pull request adds new handling in the ToolsSettings class to
resolve to the actual instance of an AMD64 MSBuild executable
to ensure we are using either the supported VS studio instance
or the latest instance available.


## Motivation and Context

This change is made due to the version of cake that we are
currently using isn't able to resolve to a Visual Studio 2022
instance, or if an instance is installed to a custom directory.

## Testing

1. Copy the files over to a local close of the chocolatey/choco repository.
2. Update the call to `SetToolSettings` and iterate through each enumeration value for `MSBuildToolSettings` that can be set
3. Verify the correct installation of Visual Studio is picked up.

**NOTE: Due to not having any legacy installations of Visual Studio installed (2017 and below), I was not able to correctly assert this resolving**

## Change Types Made

* [ ] Bug fix (non-breaking change)
* [x] Feature / Enhancement (non-breaking change)
* [ ] Breaking change (fix or feature that could cause existing functionality to change)
* [ ] PowerShell code changes.

## Related Issue

Fixes #93

## Change Checklist

* [ ] Requires a change to the documentation
* [ ] Documentation has been updated
* [ ] Tests to cover my changes, have been added
* [ ] All new and existing tests passed.
* [ ] PowerShell v2 compatibility checked.
