### PR TITLE
(#96) Adds Optional SonarQube Step

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/addins.cake
+++ b/Chocolatey.Cake.Recipe/Content/addins.cake
@@ -34,6 +34,7 @@
 #addin nuget:?package=Cake.Npm&version=0.16.0
 #addin nuget:?package=Cake.PowerShell&version=0.4.8
 #addin nuget:?package=Cake.ReSharperReports&version=0.10.0
+#addin nuget:?package=Cake.Sonar&version=1.1.26
 #addin nuget:?package=Cake.StrongNameSigner&version=0.1.0
 #addin nuget:?package=Cake.StrongNameTool&version=0.0.5
 #addin nuget:?package=Cake.Transifex&version=1.0.1

--- a/Chocolatey.Cake.Recipe/Content/credentials.cake
+++ b/Chocolatey.Cake.Recipe/Content/credentials.cake
@@ -52,6 +52,16 @@ public class PackageSourceCredentials
     }
 }
 
+public class SonarQubeCredentials
+{
+    public string Token { get; private set; }
+
+    public SonarQubeCredentials(string token)
+    {
+        Token = token;
+    }
+}
+
 public static GitHubCredentials GetGitHubCredentials(ICakeContext context)
 {
     string token = null;
@@ -73,5 +83,12 @@ public static TransifexCredentials GetTransifexCredentials(ICakeContext context)
 {
     return new TransifexCredentials(
         context.EnvironmentVariable(Environment.TransifexApiTokenVariable)
+    );
+}
+
+public static SonarQubeCredentials GetSonarQubeCredentials(ICakeContext context)
+{
+    return new SonarQubeCredentials(
+        context.EnvironmentVariable(Environment.SonarQubeTokenVariable)
     );
 }

--- a/Chocolatey.Cake.Recipe/Content/environment.cake
+++ b/Chocolatey.Cake.Recipe/Content/environment.cake
@@ -18,14 +18,23 @@ public static class Environment
     public static string DefaultPushSourceUrlVariable { get; private set; }
     public static string GitHubTokenVariable { get; private set; }
     public static string TransifexApiTokenVariable { get; private set; }
+    public static string SonarQubeTokenVariable { get; private set; }
+    public static string SonarQubeIdVariable { get; private set; }
+    public static string SonarQubeUrlVariable { get; private set; }
 
     public static void SetVariableNames(
         string defaultPushSourceUrlVariable = null,
         string gitHubTokenVariable = null,
-        string transifexApiTokenVariable = null)
+        string transifexApiTokenVariable = null,
+        string sonarQubeTokenVariable = null,
+        string sonarQubeIdVariable = null,
+        string sonarQubeUrlVariable = null)
     {
         DefaultPushSourceUrlVariable = defaultPushSourceUrlVariable ?? "NUGETDEVPUSH_SOURCE";
         GitHubTokenVariable = gitHubTokenVariable ?? "GITHUB_PAT";
         TransifexApiTokenVariable = transifexApiTokenVariable ?? "TRANSIFEX_API_TOKEN";
+        SonarQubeTokenVariable = sonarQubeTokenVariable ?? "SONARQUBE_TOKEN";
+        SonarQubeIdVariable = sonarQubeIdVariable ?? "SONARQUBE_ID";
+        SonarQubeUrlVariable = sonarQubeUrlVariable ?? "SONARQUBE_URL";
     }
 }

--- a/Chocolatey.Cake.Recipe/Content/sonarqube.cake
+++ b/Chocolatey.Cake.Recipe/Content/sonarqube.cake
@@ -1,0 +1,48 @@
+// Copyright © 2023 Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+BuildParameters.Tasks.InitializeSonarQubeTask = Task("Initialize-SonarQube")
+    .WithCriteria(() => BuildParameters.ShouldRunSonarQube, "Skipping because SonarQube has been disabled")
+    .WithCriteria(() => !string.IsNullOrEmpty(BuildParameters.SonarQubeToken), "Skipping because SonarQube Token is undefined")
+    .IsDependeeOf("Build")
+    .Does(() => RequireTool(ToolSettings.SonarQubeTool, () =>
+{
+    var SonarQubeSettings = new SonarBeginSettings
+    {
+        Key     = BuildParameters.SonarQubeId,
+        Version = BuildParameters.Version.InformationalVersion,
+        Login   = BuildParameters.SonarQubeToken
+    };
+
+    if (!string.IsNullOrEmpty(BuildParameters.SonarQubeUrl))
+    {
+        SonarQubeSettings.Url = BuildParameters.SonarQubeUrl;
+    };
+
+    SonarBegin(SonarQubeSettings);
+}));
+
+BuildParameters.Tasks.FinaliseSonarQubeTask = Task("Finalise-SonarQube")
+    .WithCriteria(() => BuildParameters.ShouldRunSonarQube, "Skipping because SonarQube has been disabled")
+    .WithCriteria(() => !string.IsNullOrEmpty(BuildParameters.SonarQubeToken), "Skipping because SonarQube Token is undefined")
+    .IsDependentOn("Initialize-SonarQube")
+    .IsDependentOn("Build")
+    .IsDependeeOf("Package")
+    .Does(() => RequireTool(ToolSettings.SonarQubeTool, () =>
+{
+    SonarEnd(new SonarEndSettings {
+        Login = BuildParameters.SonarQubeToken
+    });
+}));

--- a/Chocolatey.Cake.Recipe/Content/tasks.cake
+++ b/Chocolatey.Cake.Recipe/Content/tasks.cake
@@ -69,6 +69,10 @@ public class BuildTasks
     public CakeTaskBuilder SignAssembliesTask { get; set; }
     public CakeTaskBuilder SignMsisTask { get; set; }
 
+    // SonarQube Tasks
+    public CakeTaskBuilder InitializeSonarQubeTask { get; set; }
+    public CakeTaskBuilder FinaliseSonarQubeTask { get; set; }
+
     // GitReleaseManager Tasks
     public CakeTaskBuilder ReleaseNotesTask { get; set; }
     public CakeTaskBuilder CreateReleaseNotesTask { get; set; }

--- a/Chocolatey.Cake.Recipe/Content/toolsettings.cake
+++ b/Chocolatey.Cake.Recipe/Content/toolsettings.cake
@@ -42,6 +42,7 @@ public static class ToolSettings
     public static string ReSharperReportsTool { get; private set; }
     public static string ReSharperTools { get; private set; }
     public static string StrongNameSignerTool { get; private set; }
+    public static string SonarQubeTool { get; private set; }
     public static string TestCoverageExcludeByAttribute { get; private set; }
     public static string TestCoverageExcludeByFile { get; private set; }
     public static string TestCoverageFilter { get; private set; }
@@ -62,6 +63,7 @@ public static class ToolSettings
         string reportUnitTool = "#tool nuget:?package=ReportUnit&version=1.2.1",
         string reSharperReportsTool = "#tool nuget:?package=ReSharperReports&version=0.2.0",
         string reSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2017.2.0",
+        string sonarQubeTool = "#tool nuget:?package=MSBuild.SonarQube.Runner.Tool&version=4.8.0",
         string strongNameSignerTool = "#tool nuget:?package=Brutal.Dev.StrongNameSigner&version=2.6.0",
         string xunitTool = "#tool nuget:?package=xunit.runner.console&version=2.4.1"
     )
@@ -81,6 +83,7 @@ public static class ToolSettings
         ReSharperReportsTool = reSharperReportsTool;
         ReSharperTools = reSharperTools;
         StrongNameSignerTool = strongNameSignerTool;
+        SonarQubeTool = sonarQubeTool;
         XUnitTool = xunitTool;
     }
 


### PR DESCRIPTION
This adds build tasks for analysing and submitting results to a SonarQube instance.

It may not yet be suited to PR builds, as there are some additional settings involved, but it should suffice for scanning using the Community edition.