### PR TITLE
(#98) Adds Optional Docker Steps

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/addins.cake
+++ b/Chocolatey.Cake.Recipe/Content/addins.cake
@@ -18,6 +18,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #addin nuget:?package=Cake.Coverlet&version=2.5.4
+#addin nuget:?package=Cake.Docker&version=1.0.0
 #addin nuget:?package=Cake.Eazfuscator.Net&version=0.1.0
 #addin nuget:?package=Cake.Figlet&version=1.2.0
 #addin nuget:?package=Cake.FileHelpers&version=3.2.0

--- a/Chocolatey.Cake.Recipe/Content/credentials.cake
+++ b/Chocolatey.Cake.Recipe/Content/credentials.cake
@@ -62,6 +62,25 @@ public class SonarQubeCredentials
     }
 }
 
+public class DockerCredentials
+{
+    public string Server { get; private set; }
+    public string User { get; private set; }
+    public string Password { get; private set; }
+
+    public bool HasCredentials
+    {
+        get { return !string.IsNullOrEmpty(User) && !string.IsNullOrEmpty(Password); }
+    }
+
+    public DockerCredentials(string user, string password, string server = null)
+    {
+        Server = server;
+        User = user;
+        Password = password;
+    }
+}
+
 public static GitHubCredentials GetGitHubCredentials(ICakeContext context)
 {
     string token = null;
@@ -90,5 +109,14 @@ public static SonarQubeCredentials GetSonarQubeCredentials(ICakeContext context)
 {
     return new SonarQubeCredentials(
         context.EnvironmentVariable(Environment.SonarQubeTokenVariable)
+    );
+}
+
+public static DockerCredentials GetDockerCredentials(ICakeContext context)
+{
+    return new DockerCredentials(
+        context.EnvironmentVariable(Environment.DockerUserVariable),
+        context.EnvironmentVariable(Environment.DockerPasswordVariable),
+        context.EnvironmentVariable(Environment.DockerServerVariable)
     );
 }

--- a/Chocolatey.Cake.Recipe/Content/docker.cake
+++ b/Chocolatey.Cake.Recipe/Content/docker.cake
@@ -1,0 +1,123 @@
+// Copyright © 2023 Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+BuildParameters.Tasks.DockerLogin = Task("DockerLogin")
+    .WithCriteria(() => BuildParameters.DockerCredentials.HasCredentials, "Skipping because Docker Credentials were not provided.")
+    .Does(() => 
+{
+    DockerLogin(
+        BuildParameters.DockerCredentials.User,
+        BuildParameters.DockerCredentials.Password,
+        BuildParameters.DockerCredentials.Server
+    );
+});
+
+BuildParameters.Tasks.DockerBuild = Task("DockerBuild")
+    .Does(() =>
+{
+    var platform = BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows ? "windows" : "linux";
+
+    var dockerBuildSettings = new DockerImageBuildSettings();
+    dockerBuildSettings.Tag = new string[] {
+        string.Format("{0}/{1}:v{2}-{3}", BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.MajorMinorPatch, platform)
+    };
+    dockerBuildSettings.File = string.Format("docker/Dockerfile.{0}", platform);
+
+    if (platform == "linux")
+    {
+        dockerBuildSettings.BuildArg = new string[] {
+            "buildscript=build.official.sh"
+        };
+    }
+
+    DockerBuild(
+        dockerBuildSettings,
+        BuildParameters.RootDirectoryPath.ToString()
+    );
+});
+
+BuildParameters.Tasks.DockerPush = Task("DockerPush")
+    .WithCriteria(() => BuildParameters.IsTagged && BuildParameters.Version.MajorMinorPatch == BuildParameters.Version.FullSemVersion, "Skipping because this isn't a tagged full release build.")
+    .WithCriteria(() => BuildParameters.DockerCredentials.HasCredentials, "Skipping because Docker Credentials were not provided.")
+    .IsDependentOn("DockerLogin")
+    .IsDependentOn("DockerBuild")
+    .Does(() =>
+{
+    var platform = BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows ? "windows" : "linux";
+
+    DockerPush(
+        string.Format("{0}/{1}:v{2}-{3}", BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.MajorMinorPatch, platform)
+    );
+});
+
+BuildParameters.Tasks.DockerTagAsLatest = Task("DockerTagAsLatest")
+    .WithCriteria(() => BuildParameters.IsTagged && BuildParameters.Version.MajorMinorPatch == BuildParameters.Version.FullSemVersion, "Skipping because this isn't a tagged full release build.")
+    .WithCriteria(() => BuildParameters.DockerCredentials.HasCredentials, "Skipping because Docker Credentials were not provided.")
+    .IsDependentOn("DockerLogin")
+    .IsDependentOn("DockerBuild")
+    .IsDependentOn("DockerPush")
+    .Does(() =>
+{
+    var platform = BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows ? "windows" : "linux";
+    var latestPlatformTag = string.Format("{0}/{1}:latest-{2}", BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, platform);
+
+    DockerTag(
+        string.Format("{0}/{1}:v{2}-{3}", BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.MajorMinorPatch, platform),
+        latestPlatformTag
+    );
+
+    DockerPush(
+        latestPlatformTag
+    );
+});
+
+BuildParameters.Tasks.Docker = Task("Docker")
+    .IsDependentOn("DockerLogin")
+    .IsDependentOn("DockerBuild")
+    .IsDependentOn("DockerPush")
+    .IsDependentOn("DockerTagAsLatest");
+
+BuildParameters.Tasks.DockerManifest = Task("DockerManifest")
+    .WithCriteria(() => BuildParameters.IsTagged && BuildParameters.Version.MajorMinorPatch == BuildParameters.Version.FullSemVersion, "Skipping because this isn't a tagged full release build.")
+    .WithCriteria(() => BuildParameters.DockerCredentials.HasCredentials, "Skipping because Docker Credentials were not provided.")
+    .IsDependentOn("DockerLogin")
+    .Does(() =>
+{
+    // Note: This will fail if one of the expected tags are not available, so it's important to ensure other builds have completed.
+
+    // Create the version manifest
+    var manifestListName = string.Format("{0}/{1}:v{2}", BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.MajorMinorPatch);
+
+    DockerManifestCreate(
+        manifestListName,
+        string.Format("{0}-windows", manifestListName),
+        new string[] {
+            string.Format("{0}-linux", manifestListName)
+        }
+    );
+
+    DockerManifestPush(manifestListName);
+
+    // Create the latest manifest
+    DockerManifestCreate(
+        string.Format("{0}/{1}:latest", BuildParameters.RepositoryOwner, BuildParameters.RepositoryName),
+        string.Format("{0}/{1}:latest-windows", BuildParameters.RepositoryOwner, BuildParameters.RepositoryName),
+        new string[] {
+            string.Format("{0}/{1}:latest-linux", BuildParameters.RepositoryOwner, BuildParameters.RepositoryName)
+        }
+    );
+
+    DockerManifestPush(string.Format("{0}/{1}:latest", BuildParameters.RepositoryOwner, BuildParameters.RepositoryName));
+});

--- a/Chocolatey.Cake.Recipe/Content/environment.cake
+++ b/Chocolatey.Cake.Recipe/Content/environment.cake
@@ -21,6 +21,9 @@ public static class Environment
     public static string SonarQubeTokenVariable { get; private set; }
     public static string SonarQubeIdVariable { get; private set; }
     public static string SonarQubeUrlVariable { get; private set; }
+    public static string DockerUserVariable { get; private set; }
+    public static string DockerPasswordVariable { get; private set; }
+    public static string DockerServerVariable { get; private set; }
 
     public static void SetVariableNames(
         string defaultPushSourceUrlVariable = null,
@@ -28,7 +31,10 @@ public static class Environment
         string transifexApiTokenVariable = null,
         string sonarQubeTokenVariable = null,
         string sonarQubeIdVariable = null,
-        string sonarQubeUrlVariable = null)
+        string sonarQubeUrlVariable = null,
+        string dockerUserVariable = null,
+        string dockerPasswordVariable = null,
+        string dockerServerVariable = null)
     {
         DefaultPushSourceUrlVariable = defaultPushSourceUrlVariable ?? "NUGETDEVPUSH_SOURCE";
         GitHubTokenVariable = gitHubTokenVariable ?? "GITHUB_PAT";
@@ -36,5 +42,8 @@ public static class Environment
         SonarQubeTokenVariable = sonarQubeTokenVariable ?? "SONARQUBE_TOKEN";
         SonarQubeIdVariable = sonarQubeIdVariable ?? "SONARQUBE_ID";
         SonarQubeUrlVariable = sonarQubeUrlVariable ?? "SONARQUBE_URL";
+        DockerUserVariable = dockerUserVariable ?? "DOCKER_USER";
+        DockerPasswordVariable = dockerPasswordVariable ?? "DOCKER_PASSWORD";
+        DockerServerVariable = dockerServerVariable ?? "DOCKER_SERVER";
     }
 }

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -40,6 +40,7 @@ public static class BuildParameters
     public static string Configuration { get; private set; }
     public static string DeploymentEnvironment { get; private set; }
     public static string DevelopBranchName { get; private set; }
+    public static DockerCredentials DockerCredentials { get; private set; }
     public static bool ForceContinuousIntegration { get; private set; }
     public static FilePath FullReleaseNotesFilePath { get; private set; }
     public static Func<FilePathCollection> GetFilesToObfuscate { get; private set; }
@@ -378,6 +379,7 @@ public static class BuildParameters
         ChocolateyNupkgGlobbingPattern = chocolateyNupkgGlobbingPattern;
         ChocolateyNuspecGlobbingPattern = chocolateyNuspecGlobbingPattern;
         Configuration = context.Argument("configuration", "Release");
+        DockerCredentials = GetDockerCredentials(context);
         DeploymentEnvironment = context.Argument("environment", "Release");
         DevelopBranchName = developBranchName;
         ForceContinuousIntegration = context.Argument("forceContinuousIntegration", false);

--- a/Chocolatey.Cake.Recipe/Content/tasks.cake
+++ b/Chocolatey.Cake.Recipe/Content/tasks.cake
@@ -38,6 +38,14 @@ public class BuildTasks
     public CakeTaskBuilder CreateIssuesReportTask { get; set; }
     public CakeTaskBuilder AnalyzeTask { get; set; }
 
+    // Docker Tasks
+    public CakeTaskBuilder DockerLogin { get; set; }
+    public CakeTaskBuilder DockerBuild { get; set; }
+    public CakeTaskBuilder DockerTagAsLatest { get; set; }
+    public CakeTaskBuilder DockerPush { get; set; }
+    public CakeTaskBuilder DockerManifest { get; set; }
+    public CakeTaskBuilder Docker { get; set; }
+
     // Eazfuscator Tasks
     public CakeTaskBuilder ObfuscateAssembliesTask { get; set; }
 

--- a/Chocolatey.Cake.Recipe/Content/toolsettings.cake
+++ b/Chocolatey.Cake.Recipe/Content/toolsettings.cake
@@ -116,7 +116,7 @@ public static class ToolSettings
         // We only use MSBuild when running on Windows. Elsewhere, we use XBuild when required. As a result,
         // we only need to detect the correct version of MSBuild when running on WIndows, and when it hasn't
         // been explicitly set.
-        if (msBuildToolPath == null && BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows)
+        if (msBuildToolPath == null && BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows && !BuildParameters.Target.StartsWith("Docker"))
         {
             msBuildToolPath = ResolveVisualStudioMsBuildPath(context, BuildMSBuildToolVersion);
 


### PR DESCRIPTION
## Description Of Changes
Adds steps that can be used to produce Docker containers. Currently matched very closely to what is required with chocolatey\choco.

## Motivation and Context
We need steps to produce Docker containers.

## Testing
1. WIndows
    1. Spin up a machine compatible with the LTSC 2016 Docker containers, with Docker available
    2. Using Chocolatey\Choco as the example, so download that repository
    3. Run `.\Build.ps1 --Target Docker` from the root of the repository
    4. Test the new image with something similar to `docker run --rm chocolatey/choco:latest-windows choco.exe --version`
2. Linux
    1. Spin up an Ubuntu machine with Docker, Mono, and Dotnet available
    2. Download Chocolatey\Choco
    3. Run `sudo .\Build.sh --Target Docker`
    4. Test the new image

### Operating Systems Tested
- Windows 10
- Windows 2016
- Ubuntu 20.04

## Change Types Made

* ~[ ] Bug fix (non-breaking change).~
* [x] Feature / Enhancement (non-breaking change).
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* ~[ ] PowerShell code changes.~

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* ~[ ] All new and existing tests passed?~
* ~[ ] PowerShell code changes: PowerShell v2 compatibility checked?~

## Related Issue

Fixes #98