### PR TITLE
(#103) Adds an option to produce MSIs after the Chocolatey Package

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -450,7 +450,7 @@ BuildParameters.Tasks.BuildMsiTask = Task("Build-MSI")
     .IsDependentOn("Sign-Assemblies")
     .IsDependeeOf("Sign-Msis")
     .WithCriteria(() => BuildParameters.ShouldBuildMsi, "Skipping because building of MSI has been disabled")
-    .Does(() => RequireTool(ToolSettings.MSBuildExtensionPackTool, () => {
+    .Does(() => RequireTool(ToolSettings.WixTool, () => RequireTool(ToolSettings.MSBuildExtensionPackTool, () => {
         Information("Building MSI from the following solution: {0}", BuildParameters.SolutionFilePath);
 
         var msbuildSettings = new MSBuildSettings
@@ -473,7 +473,7 @@ BuildParameters.Tasks.BuildMsiTask = Task("Build-MSI")
 
         MSBuild(BuildParameters.SolutionFilePath, msbuildSettings);
     })
-);
+));
 
 BuildParameters.Tasks.DefaultTask = Task("Default")
     .IsDependentOn("Package");

--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -551,7 +551,6 @@ public class Builder
         BuildParameters.Tasks.CreateNuGetPackagesTask.IsDependentOn("Sign-PowerShellScripts");
         BuildParameters.Tasks.CreateNuGetPackagesTask.IsDependentOn("Sign-Assemblies");
         BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Sign-PowerShellScripts");
-        BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Sign-Msis");
         BuildParameters.Tasks.SignMsisTask.IsDependentOn("Sign-Assemblies");
         BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn(prefix + "Build");
         BuildParameters.Tasks.ObfuscateAssembliesTask.IsDependeeOf("Sign-Assemblies");
@@ -561,6 +560,16 @@ public class Builder
         BuildParameters.Tasks.InspectCodeTask.IsDependentOn(prefix + "Build");
         BuildParameters.Tasks.ConfigurationBuilderTask.IsDependentOn(prefix + "Build");
         BuildParameters.Tasks.TestTask.IsDependentOn(prefix + "Build");
+
+        if (BuildParameters.MsiUsedWithinNupkg)
+        {
+            BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Sign-Msis");
+        }
+        else
+        {
+            BuildParameters.Tasks.BuildMsiTask.IsDependentOn("Create-Chocolatey-Packages");
+            BuildParameters.Tasks.PackageTask.IsDependentOn("Sign-Msis");
+        }
 
         if (!isDotNetBuild)
         {

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -62,6 +62,7 @@ public static class BuildParameters
     public static bool IsTagged { get; private set; }
     public static string MasterBranchName { get; private set; }
     public static FilePath MilestoneReleaseNotesFilePath { get; private set; }
+    public static bool MsiUsedWithinNupkg { get; private set; }
     public static string NuGetNupkgGlobbingPattern { get; private set; }
     public static string NuGetNuspecGlobbingPattern { get; private set; }
     public static ICollection<string> NuGetSources { get; private set; }
@@ -278,6 +279,7 @@ public static class BuildParameters
         string integrationTestScriptPath = null,
         string masterBranchName = "master",
         FilePath milestoneReleaseNotesFilePath = null,
+        bool msiUsedWithinNupkg = true,
         string nuGetNupkgGlobbingPattern = "/**/*.nupkg",
         string nuGetNuspecGlobbingPattern = "/**/*.nuspec",
         ICollection<string> nuGetSources = null,
@@ -401,6 +403,7 @@ public static class BuildParameters
         IsTagged = BuildProvider.Repository.Tag.IsTag;
         MasterBranchName = masterBranchName;
         MilestoneReleaseNotesFilePath = milestoneReleaseNotesFilePath ?? RootDirectoryPath.CombineWithFilePath("CHANGELOG.md");
+        MsiUsedWithinNupkg = msiUsedWithinNupkg;
         NuGetNupkgGlobbingPattern = nuGetNupkgGlobbingPattern;
         NuGetNuspecGlobbingPattern = nuGetNuspecGlobbingPattern;
         NuGetSources = nuGetSources;

--- a/Chocolatey.Cake.Recipe/Content/toolsettings.cake
+++ b/Chocolatey.Cake.Recipe/Content/toolsettings.cake
@@ -41,11 +41,12 @@ public static class ToolSettings
     public static string ReportUnitTool { get; private set; }
     public static string ReSharperReportsTool { get; private set; }
     public static string ReSharperTools { get; private set; }
-    public static string StrongNameSignerTool { get; private set; }
     public static string SonarQubeTool { get; private set; }
+    public static string StrongNameSignerTool { get; private set; }
     public static string TestCoverageExcludeByAttribute { get; private set; }
     public static string TestCoverageExcludeByFile { get; private set; }
     public static string TestCoverageFilter { get; private set; }
+    public static string WixTool { get; private set; }
     public static string XUnitTool { get; private set; }
 
     public static void SetToolPreprocessorDirectives(
@@ -65,6 +66,7 @@ public static class ToolSettings
         string reSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2017.2.0",
         string sonarQubeTool = "#tool nuget:?package=MSBuild.SonarQube.Runner.Tool&version=4.8.0",
         string strongNameSignerTool = "#tool nuget:?package=Brutal.Dev.StrongNameSigner&version=2.6.0",
+        string wixTool = "#tool nuget:?package=WiX&version=3.11.2",
         string xunitTool = "#tool nuget:?package=xunit.runner.console&version=2.4.1"
     )
     {
@@ -82,8 +84,9 @@ public static class ToolSettings
         ReportUnitTool = reportUnitTool;
         ReSharperReportsTool = reSharperReportsTool;
         ReSharperTools = reSharperTools;
-        StrongNameSignerTool = strongNameSignerTool;
         SonarQubeTool = sonarQubeTool;
+        StrongNameSignerTool = strongNameSignerTool;
+        WixTool = wixTool;
         XUnitTool = xunitTool;
     }
 


### PR DESCRIPTION
## Description Of Changes
- Adds a new option to produce the MSI after the Chocolatey package
    - This new option, `MsiUsedWithinNukpg`, defaults to the current behaviour (true)
    - Naming is hard, and I'm happy to reverse the logic and rename this
    - When set to `false`, dependencies for the MSI steps are modified such that it is produced after any Chocolatey packages
- Adds a new tool for WiX, such that projects don't need to embed or handle providing these files separately
    - This actually shouldn't break existing projects that use the MSI functionality (e.g. ChocolateyGUI) as it will load the files to the root tools directory but not change any existing tools - but they should be updated. I have a branch ready for GUI, whenever this CCR update is released and versioned.

## Motivation and Context
- We needed to produce an MSI containing a Chocolatey Package

## Testing
1. Load the ENGTASKS-2800/msiBuild branch of chocolatey/choco
2. Add these changes to the Chocoatey Cake Recipe in use
3. Run a tagged build (or disable the added requirement for MSIs to build on a tagged build in the recipe.cake file)
4. Find an MSI within `code_drop/MSIs` (should be identical to previously produced Choco CLI MSIs)

### Operating Systems Testing
- Windows 10
- Windows 2019

## Change Types Made

* ~[ ] Bug fix (non-breaking change).~
* [x] Feature / Enhancement (non-breaking change).
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* ~[ ] PowerShell code changes.~

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* [ ] All new and existing tests passed?
* ~[ ] PowerShell code changes: PowerShell v2 compatibility checked?~

## Related Issue

Fixes #103
