### PR TITLE
(#110)(ENGTASKS-3098) Add optional Dependency-Check Step

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/addins.cake
+++ b/Chocolatey.Cake.Recipe/Content/addins.cake
@@ -18,6 +18,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #addin nuget:?package=Cake.Coverlet&version=2.5.4
+#addin nuget:?package=Cake.DependencyCheck&version=1.2.0
 #addin nuget:?package=Cake.Discord&version=0.2.1
 #addin nuget:?package=Cake.Docker&version=1.0.0
 #addin nuget:?package=Cake.Eazfuscator.Net&version=0.1.0

--- a/Chocolatey.Cake.Recipe/Content/dependencyCheck.cake
+++ b/Chocolatey.Cake.Recipe/Content/dependencyCheck.cake
@@ -49,7 +49,7 @@ BuildParameters.Tasks.DependencyCheckTask = Task("Dependency-Check")
         Project = BuildParameters.ProductName,
         Scan    = BuildParameters.SourceDirectoryPath.FullPath,
         Format  = "ALL",
-        Out     = BuildParameters.RootDirectoryPath.FullPath
+        Out     = BuildParameters.Paths.Directories.DependencyCheckReports
     };
 
     DependencyCheck(DependencyCheckSettings);

--- a/Chocolatey.Cake.Recipe/Content/dependencyCheck.cake
+++ b/Chocolatey.Cake.Recipe/Content/dependencyCheck.cake
@@ -1,0 +1,56 @@
+// Copyright © 2023 Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+BuildParameters.Tasks.DependencyCheckTask = Task("Dependency-Check")
+    .WithCriteria(() => BuildParameters.ShouldRunDependencyCheck, "Skipping because DependencyCheck has been disabled")
+    .WithCriteria(() => !string.IsNullOrEmpty(BuildParameters.SonarQubeToken), "Skipping because SonarQube Token is undefined")
+    .IsDependentOn("Initialize-SonarQube")
+    .IsDependeeOf("Finalise-SonarQube")
+    .Does(() => RequireTool(ToolSettings.DependencyCheckTool, () =>
+{
+    DownloadFile(
+        "https://github.com/jeremylong/DependencyCheck/releases/download/v8.2.1/dependency-check-8.2.1-release.zip",
+        BuildParameters.RootDirectoryPath.CombineWithFilePath("dependency-check.zip")
+    );
+
+    Unzip(
+        BuildParameters.RootDirectoryPath.CombineWithFilePath("dependency-check.zip"),
+        BuildParameters.RootDirectoryPath.FullPath
+    );
+
+    CopyDirectory(
+        BuildParameters.RootDirectoryPath.Combine("dependency-check"),
+        BuildParameters.RootDirectoryPath.Combine("tools/DependencyCheck.Runner.Tool.3.2.1/tools")
+    );
+
+    DeleteDirectory(
+        BuildParameters.RootDirectoryPath.Combine("dependency-check"),
+        new DeleteDirectorySettings {
+            Recursive = true,
+            Force     = true
+        }
+    );
+
+    DeleteFile(BuildParameters.RootDirectoryPath.CombineWithFilePath("dependency-check.zip"));
+
+    var DependencyCheckSettings = new DependencyCheckSettings {
+        Project = BuildParameters.ProductName,
+        Scan    = BuildParameters.SourceDirectoryPath.FullPath,
+        Format  = "ALL",
+        Out     = BuildParameters.RootDirectoryPath.FullPath
+    };
+
+    DependencyCheck(DependencyCheckSettings);
+}));

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -165,6 +165,7 @@ public static class BuildParameters
     public static bool ShouldReportUnitTestResults { get; private set; }
     public static bool ShouldRunAnalyze { get; private set; }
     public static bool ShouldRunChocolatey { get; private set; }
+    public static bool ShouldRunDependencyCheck { get; private set; }
     public static bool ShouldRunDocker { get; private set; }
     public static bool ShouldRunDotNetPack { get; private set; }
     public static bool ShouldRunDotNetTest { get; private set; }
@@ -295,6 +296,7 @@ public static class BuildParameters
         context.Information("ShouldReportUnitTestResults: {0}", BuildParameters.ShouldReportUnitTestResults);
         context.Information("ShouldRunAnalyze: {0}", BuildParameters.ShouldRunAnalyze);
         context.Information("ShouldRunChocolatey: {0}", BuildParameters.ShouldRunChocolatey);
+        context.Information("ShouldRunDependencyCheck: {0}", BuildParameters.ShouldRunDependencyCheck);
         context.Information("ShouldRunDocker: {0}", BuildParameters.ShouldRunDocker);
         context.Information("ShouldRunDotNetPack: {0}", BuildParameters.ShouldRunDotNetPack);
         context.Information("ShouldRunDotNetTest: {0}", BuildParameters.ShouldRunDotNetTest);
@@ -400,6 +402,7 @@ public static class BuildParameters
         bool shouldReportUnitTestResults = true,
         bool shouldRunAnalyze = true,
         bool shouldRunChocolatey = true,
+        bool shouldRunDependencyCheck = false,
         bool shouldRunDocker = true,
         bool shouldRunDotNetPack = false,
         bool shouldRunDotNetTest = true,
@@ -654,6 +657,18 @@ public static class BuildParameters
         if (context.HasArgument("shouldRunChocolatey"))
         {
             ShouldRunChocolatey = context.Argument<bool>("shouldRunChocolatey");
+        }
+
+        if (context.HasArgument("shouldRunDependencyCheck"))
+        {
+            ShouldRunDependencyCheck = context.Argument<bool>("shouldRunDependencyCheck");
+        }
+        else
+        {
+            if (BuildParameters.IsTagged && !BuildParameters.IsLocalBuild)
+            {
+                ShouldRunDependencyCheck = true;
+            }
         }
 
         ShouldRunDocker = shouldRunDocker;

--- a/Chocolatey.Cake.Recipe/Content/paths.cake
+++ b/Chocolatey.Cake.Recipe/Content/paths.cake
@@ -47,10 +47,14 @@ public class BuildPaths
         var nuGetPackagesOutputDirectory = packagesDirectory + "/NuGet";
         var chocolateyPackagesOutputDirectory = packagesDirectory + "/Chocolatey";
 
+        var dependencyCheckReportsDirectory = buildDirectoryPath + "/DependencyCheckReports";
+
         // Files
         var testCoverageOutputFilePath = ((DirectoryPath)testCoverageDirectory).CombineWithFilePath("OpenCover.xml");
         var solutionInfoFilePath = ((DirectoryPath)BuildParameters.SourceDirectoryPath).CombineWithFilePath("SolutionVersion.cs");
         var buildLogFilePath = ((DirectoryPath)buildDirectoryPath).CombineWithFilePath("MsBuild.log");
+        var dependencyCheckJsonReportFilePath = ((DirectoryPath)dependencyCheckReportsDirectory).CombineWithFilePath("dependency-check-report.json");
+        var dependencyCheckHtmlReportFilePath = ((DirectoryPath)dependencyCheckReportsDirectory).CombineWithFilePath("dependency-check-report.html");
 
         var repoFilesPaths = new FilePath[] {
             "LICENSE",
@@ -76,14 +80,17 @@ public class BuildPaths
             nuGetPackagesOutputDirectory,
             chocolateyPackagesOutputDirectory,
             packagesDirectory,
-            environmentSettingsDirectory
+            environmentSettingsDirectory,
+            dependencyCheckReportsDirectory
             );
 
         var buildFiles = new BuildFiles(
             repoFilesPaths,
             testCoverageOutputFilePath,
             solutionInfoFilePath,
-            buildLogFilePath
+            buildLogFilePath,
+            dependencyCheckJsonReportFilePath,
+            dependencyCheckHtmlReportFilePath
             );
 
         return new BuildPaths
@@ -108,13 +115,17 @@ public class BuildFiles
         FilePath[] repoFilesPaths,
         FilePath testCoverageOutputFilePath,
         FilePath solutionInfoFilePath,
-        FilePath buildLogFilePath
+        FilePath buildLogFilePath,
+        FilePath dependencyCheckJsonReportFilePath,
+        FilePath dependencyCheckHtmlReportFilePath
         )
     {
         RepoFilesPaths = Filter(repoFilesPaths);
         TestCoverageOutputFilePath = testCoverageOutputFilePath;
         SolutionInfoFilePath = solutionInfoFilePath;
         BuildLogFilePath = buildLogFilePath;
+        DependencyCheckJsonReportFilePath = dependencyCheckJsonReportFilePath;
+        DependencyCheckHtmlReportFilePath = dependencyCheckHtmlReportFilePath;
     }
 
     private static FilePath[] Filter(FilePath[] files)
@@ -152,6 +163,7 @@ public class BuildDirectories
     public DirectoryPath ChocolateyPackages { get; private set; }
     public DirectoryPath Packages { get; private set; }
     public DirectoryPath EnvironmentSettings { get; private set; }
+    public DirectoryPath DependencyCheckReports { get; private set; }
     public ICollection<DirectoryPath> ToClean { get; private set; }
 
     public BuildDirectories(
@@ -173,7 +185,8 @@ public class BuildDirectories
         DirectoryPath nuGetPackages,
         DirectoryPath chocolateyPackages,
         DirectoryPath packages,
-        DirectoryPath environmentSettings
+        DirectoryPath environmentSettings,
+        DirectoryPath dependencyCheckReports
         )
     {
         Build = build;
@@ -194,6 +207,7 @@ public class BuildDirectories
         NuGetPackages = nuGetPackages;
         ChocolateyPackages = chocolateyPackages;
         EnvironmentSettings = environmentSettings;
+        DependencyCheckReports = dependencyCheckReports;
         Packages = packages;
 
         ToClean = new[] {

--- a/Chocolatey.Cake.Recipe/Content/sonarqube.cake
+++ b/Chocolatey.Cake.Recipe/Content/sonarqube.cake
@@ -30,6 +30,13 @@ BuildParameters.Tasks.InitializeSonarQubeTask = Task("Initialize-SonarQube")
         SonarQubeSettings.Url = BuildParameters.SonarQubeUrl;
     };
 
+    if (BuildParameters.ShouldRunDependencyCheck)
+    {
+        SonarQubeSettings.ArgumentCustomization = args => args
+            .Append(string.Format("/d:sonar.dependencyCheck.jsonReportPath={0}", BuildParameters.RootDirectoryPath.CombineWithFilePath("dependency-check-report.json")))
+            .Append(string.Format("/d:sonar.dependencyCheck.htmlReportPath={0}", BuildParameters.RootDirectoryPath.CombineWithFilePath("dependency-check-report.html")));
+    };
+
     SonarBegin(SonarQubeSettings);
 }));
 

--- a/Chocolatey.Cake.Recipe/Content/sonarqube.cake
+++ b/Chocolatey.Cake.Recipe/Content/sonarqube.cake
@@ -33,8 +33,8 @@ BuildParameters.Tasks.InitializeSonarQubeTask = Task("Initialize-SonarQube")
     if (BuildParameters.ShouldRunDependencyCheck)
     {
         SonarQubeSettings.ArgumentCustomization = args => args
-            .Append(string.Format("/d:sonar.dependencyCheck.jsonReportPath={0}", BuildParameters.RootDirectoryPath.CombineWithFilePath("dependency-check-report.json")))
-            .Append(string.Format("/d:sonar.dependencyCheck.htmlReportPath={0}", BuildParameters.RootDirectoryPath.CombineWithFilePath("dependency-check-report.html")));
+            .Append(string.Format("/d:sonar.dependencyCheck.jsonReportPath={0}", BuildParameters.Paths.Files.DependencyCheckJsonReportFilePath))
+            .Append(string.Format("/d:sonar.dependencyCheck.htmlReportPath={0}", BuildParameters.Paths.Files.DependencyCheckHtmlReportFilePath));
     };
 
     SonarBegin(SonarQubeSettings);

--- a/Chocolatey.Cake.Recipe/Content/tasks.cake
+++ b/Chocolatey.Cake.Recipe/Content/tasks.cake
@@ -38,6 +38,9 @@ public class BuildTasks
     public CakeTaskBuilder CreateIssuesReportTask { get; set; }
     public CakeTaskBuilder AnalyzeTask { get; set; }
 
+    // Dependency-Check Tasks
+    public CakeTaskBuilder DependencyCheckTask { get; set; }
+
     // Docker Tasks
     public CakeTaskBuilder DockerLogin { get; set; }
     public CakeTaskBuilder DockerBuild { get; set; }

--- a/Chocolatey.Cake.Recipe/Content/toolsettings.cake
+++ b/Chocolatey.Cake.Recipe/Content/toolsettings.cake
@@ -26,6 +26,7 @@ public static class ToolSettings
     public static string XBuildPlatformTarget { get; private set; }
     public static FilePath EazfuscatorToolLocation { get; private set; }
     public static string AmazonLambdaGlobalTool { get; private set; }
+    public static string DependencyCheckTool { get; private set; }
     public static string GitVersionGlobalTool { get; private set; }
     public static string GitVersionTool { get; private set; }
     public static string GitReleaseManagerGlobalTool { get; private set; }
@@ -51,6 +52,7 @@ public static class ToolSettings
 
     public static void SetToolPreprocessorDirectives(
         string amazonLambdaGlobalTool = "#tool dotnet:?package=amazon.lambda.tools&version=5.4.5",
+        string dependencyCheckTool = "#tool nuget:?package=DependencyCheck.Runner.Tool&version=3.2.1&include=./**/dependency-check.sh&include=./**/dependency-check.bat",
         string gitVersionGlobalTool = "#tool dotnet:?package=GitVersion.Tool&version=5.10.1",
         string gitVersionTool = "#tool nuget:?package=GitVersion.CommandLine&version=5.10.1",
         string gitReleaseManagerGlobalTool = "#tool dotnet:?package=GitReleaseManager.Tool&version=0.13.0",
@@ -71,6 +73,7 @@ public static class ToolSettings
     )
     {
         AmazonLambdaGlobalTool = amazonLambdaGlobalTool;
+        DependencyCheckTool = dependencyCheckTool;
         GitVersionGlobalTool = gitVersionGlobalTool;
         GitVersionTool = gitVersionTool;
         GitReleaseManagerGlobalTool = gitReleaseManagerGlobalTool;


### PR DESCRIPTION
## Description Of Changes

This PR adds a Dependency-Check step that, by default, runs under same conditions as the SonarQube step that was added in #97.

The task should run before the `Initialize-SonarQube` task as that step needs to know about the reports generated by Dependency-Check.

## Motivation and Context

Enables management of vulnerabilities in project dependencies, including consumption of reports via the SonarQube interface alongside direct code issues.

## Testing

Testing is pending completion.

### Operating Systems Testing

N/A

## Change Types Made

* ~[ ] Bug fix (non-breaking change).~
* [x] Feature / Enhancement (non-breaking change).
* ~[ ] Breaking change (fix or feature that could cause existing functionality to change).~
* ~[ ] Documentation changes.~
* ~[ ] PowerShell code changes.~

## Change Checklist

* ~[ ] Requires a change to the documentation.~
* ~[ ] Documentation has been updated.~
* ~[ ] Tests to cover my changes, have been added.~
* ~[ ] All new and existing tests passed?~
* ~[ ] PowerShell code changes: PowerShell v2 compatibility checked?~

## Related Issue

* Fixes #110
* ENGTASKS-3098