### PR TITLE
(#107) Add sending of notifications

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/addins.cake
+++ b/Chocolatey.Cake.Recipe/Content/addins.cake
@@ -18,6 +18,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #addin nuget:?package=Cake.Coverlet&version=2.5.4
+#addin nuget:?package=Cake.Discord&version=0.2.1
 #addin nuget:?package=Cake.Docker&version=1.0.0
 #addin nuget:?package=Cake.Eazfuscator.Net&version=0.1.0
 #addin nuget:?package=Cake.Figlet&version=1.2.0
@@ -32,13 +33,16 @@
 #addin nuget:?package=Cake.Issues.Reporting.Generic&version=0.7.2
 #addin nuget:?package=Cake.Json&version=4.0.0
 #addin nuget:?package=Cake.Kudu&version=0.8.0
+#addin nuget:?package=Cake.Mastodon&version=1.0.0
 #addin nuget:?package=Cake.Npm&version=0.16.0
 #addin nuget:?package=Cake.PowerShell&version=0.4.8
 #addin nuget:?package=Cake.ReSharperReports&version=0.10.0
+#addin nuget:?package=Cake.Slack&version=0.13.0
 #addin nuget:?package=Cake.Sonar&version=1.1.26
 #addin nuget:?package=Cake.StrongNameSigner&version=0.1.0
 #addin nuget:?package=Cake.StrongNameTool&version=0.0.5
 #addin nuget:?package=Cake.Transifex&version=1.0.1
+#addin nuget:?package=Cake.Twitter&version=0.10.1
 #addin nuget:?package=MagicChunks&version=2.0.0.119
 
 // TODO: Conditionally decide whether to install packages or not

--- a/Chocolatey.Cake.Recipe/Content/credentials.cake
+++ b/Chocolatey.Cake.Recipe/Content/credentials.cake
@@ -13,6 +13,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+public class DiscordCredentials
+{
+    public string WebHookUrl { get; private set; }
+    public string UserName { get; private set; }
+    public string AvatarUrl { get; private set; }
+
+    public DiscordCredentials(string webHookUrl, string userName, string avatarUrl)
+    {
+        WebHookUrl = webHookUrl;
+        UserName = userName;
+        AvatarUrl = avatarUrl;
+    }
+}
+
 public class GitHubCredentials
 {
     public string Token { get; private set; }
@@ -20,6 +34,30 @@ public class GitHubCredentials
     public GitHubCredentials(string token)
     {
         Token = token;
+    }
+}
+
+public class MastodonCredentials
+{
+    public string Token { get; private set; }
+    public string HostName { get; private set; }
+
+    public MastodonCredentials(string token, string hostName)
+    {
+        Token = token;
+        HostName = hostName;
+    }
+}
+
+public class SlackCredentials
+{
+    public string Channel { get; private set; }
+    public string WebHookUrl { get; private set; }
+
+    public SlackCredentials(string channel, string webHookUrl)
+    {
+        Channel = channel;
+        WebHookUrl = webHookUrl;
     }
 }
 
@@ -35,6 +73,22 @@ public class TransifexCredentials
     public TransifexCredentials(string apiToken)
     {
         ApiToken = apiToken;
+    }
+}
+
+public class TwitterCredentials
+{
+    public string ConsumerKey { get; private set; }
+    public string ConsumerSecret { get; private set; }
+    public string AccessToken { get; private set; }
+    public string AccessTokenSecret { get; private set; }
+
+    public TwitterCredentials(string consumerKey, string consumerSecret, string accessToken, string accessTokenSecret)
+    {
+        ConsumerKey = consumerKey;
+        ConsumerSecret = consumerSecret;
+        AccessToken = accessToken;
+        AccessTokenSecret = accessTokenSecret;
     }
 }
 
@@ -81,6 +135,15 @@ public class DockerCredentials
     }
 }
 
+public static DiscordCredentials GetDiscordCredentials(ICakeContext context)
+{
+    return new DiscordCredentials(
+        context.EnvironmentVariable(Environment.DiscordWebHookUrlVariable),
+        context.EnvironmentVariable(Environment.DiscordUserNameVariable),
+        context.EnvironmentVariable(Environment.DiscordAvatarUrlVariable)
+    );
+}
+
 public static GitHubCredentials GetGitHubCredentials(ICakeContext context)
 {
     string token = null;
@@ -98,10 +161,36 @@ public static GitHubCredentials GetGitHubCredentials(ICakeContext context)
     return new GitHubCredentials(token);
 }
 
+public static MastodonCredentials GetMastodonCredentials(ICakeContext context)
+{
+    return new MastodonCredentials(
+        context.EnvironmentVariable(Environment.MastodonTokenVariable),
+        context.EnvironmentVariable(Environment.MastodonHostNameVariable)
+    );
+}
+
+public static SlackCredentials GetSlackCredentials(ICakeContext context)
+{
+    return new SlackCredentials(
+        context.EnvironmentVariable(Environment.SlackChannelVariable),
+        context.EnvironmentVariable(Environment.SlackWebHookUrlVariable)
+    );
+}
+
 public static TransifexCredentials GetTransifexCredentials(ICakeContext context)
 {
     return new TransifexCredentials(
         context.EnvironmentVariable(Environment.TransifexApiTokenVariable)
+    );
+}
+
+public static TwitterCredentials GetTwitterCredentials(ICakeContext context)
+{
+    return new TwitterCredentials(
+        context.EnvironmentVariable(Environment.TwitterConsumerKeyVariable),
+        context.EnvironmentVariable(Environment.TwitterConsumerSecretVariable),
+        context.EnvironmentVariable(Environment.TwitterAccessTokenVariable),
+        context.EnvironmentVariable(Environment.TwitterAccessTokenSecretVariable)
     );
 }
 

--- a/Chocolatey.Cake.Recipe/Content/environment.cake
+++ b/Chocolatey.Cake.Recipe/Content/environment.cake
@@ -16,8 +16,19 @@
 public static class Environment
 {
     public static string DefaultPushSourceUrlVariable { get; private set; }
+    public static string DiscordWebHookUrlVariable { get; private set; }
+    public static string DiscordUserNameVariable { get; private set; }
+    public static string DiscordAvatarUrlVariable { get; private set; }
     public static string GitHubTokenVariable { get; private set; }
+    public static string MastodonHostNameVariable { get; private set; }
+    public static string MastodonTokenVariable { get; private set; }
+    public static string SlackChannelVariable { get; private set; }
+    public static string SlackWebHookUrlVariable { get; private set; }
     public static string TransifexApiTokenVariable { get; private set; }
+    public static string TwitterConsumerKeyVariable { get; private set; }
+    public static string TwitterConsumerSecretVariable { get; private set; }
+    public static string TwitterAccessTokenVariable { get; private set; }
+    public static string TwitterAccessTokenSecretVariable { get; private set; }    
     public static string SonarQubeTokenVariable { get; private set; }
     public static string SonarQubeIdVariable { get; private set; }
     public static string SonarQubeUrlVariable { get; private set; }
@@ -27,8 +38,19 @@ public static class Environment
 
     public static void SetVariableNames(
         string defaultPushSourceUrlVariable = null,
+        string discordWebHookUrlVariable = null,
+        string discordUserNameVariable = null,
+        string discordAvatarUrlVariable = null,
         string gitHubTokenVariable = null,
+        string mastodonHostNameVariable = null,
+        string mastodonTokenVariable = null,
+        string slackChannelVariable = null,
+        string slackWebHookUrlVariable = null,
         string transifexApiTokenVariable = null,
+        string twitterConsumerKeyVariable = null,
+        string twitterConsumerSecretVariable = null,
+        string twitterAccessTokenVariable = null,
+        string twitterAccessTokenSecretVariable = null,
         string sonarQubeTokenVariable = null,
         string sonarQubeIdVariable = null,
         string sonarQubeUrlVariable = null,
@@ -37,8 +59,19 @@ public static class Environment
         string dockerServerVariable = null)
     {
         DefaultPushSourceUrlVariable = defaultPushSourceUrlVariable ?? "NUGETDEVPUSH_SOURCE";
+        DiscordWebHookUrlVariable = discordWebHookUrlVariable ?? "DISCORD_WEBHOOKURL";
+        DiscordUserNameVariable = discordUserNameVariable ?? "DISCORD_USERNAME";
+        DiscordAvatarUrlVariable = discordAvatarUrlVariable ?? "DISCORD_AVATARURL";
         GitHubTokenVariable = gitHubTokenVariable ?? "GITHUB_PAT";
+        MastodonHostNameVariable = mastodonHostNameVariable ?? "MASTODON_HOSTNAME";
+        MastodonTokenVariable = mastodonTokenVariable ?? "MASTODON_TOKEN";
+        SlackChannelVariable = slackChannelVariable ?? "SLACK_CHANNEL";
+        SlackWebHookUrlVariable = slackWebHookUrlVariable ?? "SLACK_WEBHOOKURL";
         TransifexApiTokenVariable = transifexApiTokenVariable ?? "TRANSIFEX_API_TOKEN";
+        TwitterConsumerKeyVariable = twitterConsumerKeyVariable ?? "TWITTER_CONSUMER_KEY";
+        TwitterConsumerSecretVariable = twitterConsumerSecretVariable ?? "TWITTER_CONSUMER_SECRET";
+        TwitterAccessTokenVariable = twitterAccessTokenVariable ?? "TWITTER_ACCESS_TOKEN";
+        TwitterAccessTokenSecretVariable = twitterAccessTokenSecretVariable ?? "TWITTER_ACCESS_TOKEN_SECRET";        
         SonarQubeTokenVariable = sonarQubeTokenVariable ?? "SONARQUBE_TOKEN";
         SonarQubeIdVariable = sonarQubeIdVariable ?? "SONARQUBE_ID";
         SonarQubeUrlVariable = sonarQubeUrlVariable ?? "SONARQUBE_URL";

--- a/Chocolatey.Cake.Recipe/Content/notifcations.cake
+++ b/Chocolatey.Cake.Recipe/Content/notifcations.cake
@@ -1,0 +1,187 @@
+public void SendMessageToDiscord(string message)
+{
+    try
+    {
+        Information("Sending message to Discord...");
+        
+        var postMessageResult = Discord.Chat.PostMessage(
+            webHookUrl: BuildParameters.Discord.WebHookUrl,
+            content: message,
+            messageSettings: new DiscordChatMessageSettings {
+                UserName = BuildParameters.Discord.UserName,
+                AvatarUrl = new Uri(BuildParameters.Discord.AvatarUrl)
+            }
+        );
+
+        if (postMessageResult.Ok)
+        {
+            Information("Discord message {0} successfully sent", postMessageResult.TimeStamp);
+        }
+        else
+        {
+            Error("Failed to send Discord message: {0}", postMessageResult.Error);
+        }
+    }
+    catch (Exception ex)
+    {
+        Error("{0}", ex);
+    }
+}
+
+public void SendMessageToMastodon(string message)
+{
+    try
+    {
+        Information("Sending message to Mastodon...");
+
+        var result = MastodonSendToot(
+            hostName: BuildParameters.Mastodon.HostName,
+            accessToken: BuildParameters.Mastodon.Token, 
+            text: message, 
+            idempotencyKey: Guid.NewGuid().ToString());
+
+        if (result.IsSuccess)
+        {
+            Information("Mastodon messsage successfully sent");
+        }
+        else
+        {
+            Error("Failed to send Mastodon message: {0}", result.ReasonPhrase);
+        }
+    }
+    catch (Exception ex)
+    {
+        Error("{0}", ex);
+    }
+}
+
+public void SendMessageToSlackChannel(string message)
+{
+    try
+    {
+        Information("Sending message to Slack...");
+
+        var postMessageResult = Slack.Chat.PostMessage(
+                    channel: BuildParameters.Slack.Channel,
+                    text: message,
+                    messageSettings: new SlackChatMessageSettings { IncomingWebHookUrl = BuildParameters.Slack.WebHookUrl }
+            );
+
+        if (postMessageResult.Ok)
+        {
+            Information("Slack Message {0} successfully sent", postMessageResult.TimeStamp);
+        }
+        else
+        {
+            Error("Failed to send Slack message: {0}", postMessageResult.Error);
+        }
+    }
+    catch (Exception ex)
+    {
+        Error("{0}", ex);
+    }
+}
+
+public void SendMessageToTwitter(string message)
+{
+    try
+    {
+        Information("Sending message to Twitter...");
+
+        TwitterSendTweet(BuildParameters.Twitter.ConsumerKey,
+                         BuildParameters.Twitter.ConsumerSecret,
+                         BuildParameters.Twitter.AccessToken,
+                         BuildParameters.Twitter.AccessTokenSecret,
+                         message);
+
+        Information("Twitter message successfully sent.");
+    }
+    catch (Exception ex)
+    {
+        Error("{0}", ex);
+    }
+}
+
+BuildParameters.Tasks.SendNotificationsTask = Task("Send-Notifications")
+    .Does(() => 
+{
+    if (FileExists("./.notifications/discord.txt"))
+    {
+        if (BuildParameters.CanPostToDiscord && BuildParameters.ShouldPostToDiscord)
+        {
+            var formattedMessage = System.IO.File.ReadAllText("./.notifications/discord.txt");
+            var messageArguments = BuildParameters.DiscordMessageArguments(BuildParameters.Version);
+            
+            //Information(formattedMessage, messageArguments);
+            SendMessageToDiscord(string.Format(formattedMessage, messageArguments));
+        }
+        else
+        {
+            Warning("Unable to send Discord message. CanPostToDiscord: {0}, ShouldPostToDiscord: {1}", BuildParameters.CanPostToDiscord, BuildParameters.ShouldPostToDiscord);
+        }
+    }
+    else
+    {
+        Information("Skipping sending notiifation to Discord, since input template file does not exist.");
+    }
+
+    if (FileExists("./.notifications/mastodon.txt"))
+    {
+        if (BuildParameters.CanPostToMastodon && BuildParameters.ShouldPostToMastodon)
+        {
+            var formattedMessage = System.IO.File.ReadAllText("./.notifications/mastodon.txt");
+            var messageArguments = BuildParameters.MastodonMessageArguments(BuildParameters.Version);
+
+            //Information(formattedMessage, messageArguments);
+            SendMessageToMastodon(string.Format(formattedMessage, messageArguments));
+        }
+        else
+        {
+            Warning("Unable to send Mastodon message. CanPostToMastodon: {0}, ShouldPostToMastodon: {1}", BuildParameters.CanPostToMastodon, BuildParameters.ShouldPostToMastodon);
+        }
+    }
+    else
+    {
+        Information("Skipping sending notiifation to Mastodon, since input template file does not exist.");
+    }
+
+    if (FileExists("./.notifications/slack.txt"))
+    {
+        if (BuildParameters.CanPostToSlack && BuildParameters.ShouldPostToSlack)
+        {
+            var formattedMessage = System.IO.File.ReadAllText("./.notifications/slack.txt");
+            var messageArguments = BuildParameters.SlackMessageArguments(BuildParameters.Version);
+
+            //Information(formattedMessage, messageArguments);
+            SendMessageToSlackChannel(string.Format(formattedMessage, messageArguments));
+        }
+        else
+        {
+            Warning("Unable to send Slack message. CanPostToSlack: {0}, ShouldPostToSlack: {1}", BuildParameters.CanPostToSlack, BuildParameters.ShouldPostToSlack);
+        }
+    }
+    else
+    {
+        Information("Skipping sending notiifation to Slack, since input template file does not exist.");
+    }
+
+    if (FileExists("./.notifications/twitter.txt"))
+    {
+        if (BuildParameters.CanPostToTwitter && BuildParameters.ShouldPostToTwitter)
+        {
+            var formattedMessage = System.IO.File.ReadAllText("./.notifications/twitter.txt");
+            var messageArguments = BuildParameters.TwitterMessageArguments(BuildParameters.Version);
+
+            Information(formattedMessage, messageArguments);
+            //SendMessageToTwitter(string.Format(formattedMessage, messageArguments));
+        }
+        else
+        {
+            Warning("Unable to send Twitter message. CanPostToTwitter: {0}, ShouldPostToTwitter: {1}", BuildParameters.CanPostToTwitter, BuildParameters.ShouldPostToTwitter);
+        }
+    }
+    else
+    {
+        Information("Skipping sending notiifation to Twitter, since input template file does not exist.");
+    }
+});

--- a/Chocolatey.Cake.Recipe/Content/tasks.cake
+++ b/Chocolatey.Cake.Recipe/Content/tasks.cake
@@ -97,4 +97,7 @@ public class BuildTasks
 
     // ILMerge Tasks
     public CakeTaskBuilder ILMergeTask { get; set; }
+
+    // Notification Tasks
+    public CakeTaskBuilder SendNotificationsTask { get; set; }
 }


### PR DESCRIPTION
## Description Of Changes

This commit adds the ability to send notifications to Mastodon, Discord, and Slack. There is also a partial implementation of posting to Twitter but this is known not to work, since there has been a change to the Twitter API.  In order for notifications to be sent, the necessary environment variables need to be set.  By default, an attempt will be made to send a notification to all configured destinations, when running --target=send-notifications, but this can be overridden either through setting the "should" parameter in the recipe.cake file, or by passing the "should" command line option to false.

## Motivation and Context

We need to be more consistent about how/when notifications are made, and what information is sent out.

## Testing

The changes in this PR have been tested throughout the last few releases of Chocolatey products, and everything has worked as expected.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #107 