### PR TITLE
(#127)(ENGTASKS-3098) Use absolute paths for Dependency-Check generated reports

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/sonarqube.cake
+++ b/Chocolatey.Cake.Recipe/Content/sonarqube.cake
@@ -33,8 +33,8 @@ BuildParameters.Tasks.InitializeSonarQubeTask = Task("Initialize-SonarQube")
     if (BuildParameters.ShouldRunDependencyCheck)
     {
         SonarQubeSettings.ArgumentCustomization = args => args
-            .Append(string.Format("/d:sonar.dependencyCheck.jsonReportPath={0}", BuildParameters.Paths.Files.DependencyCheckJsonReportFilePath))
-            .Append(string.Format("/d:sonar.dependencyCheck.htmlReportPath={0}", BuildParameters.Paths.Files.DependencyCheckHtmlReportFilePath));
+            .Append(string.Format("/d:sonar.dependencyCheck.jsonReportPath={0}", MakeAbsolute(BuildParameters.Paths.Files.DependencyCheckJsonReportFilePath)))
+            .Append(string.Format("/d:sonar.dependencyCheck.htmlReportPath={0}", MakeAbsolute(BuildParameters.Paths.Files.DependencyCheckHtmlReportFilePath)));
     };
 
     SonarBegin(SonarQubeSettings);


### PR DESCRIPTION
## Description Of Changes

The PR uses the [MakeAbsolute](https://cakebuild.net/api/Cake.Common.IO/FileAliases/8DF5B98C) method to ensure that the absolute path is used by SonarQube for the HTML and JSON reports generated by Dependency-Check.

## Motivation and Context

These paths are specified in the `Initialise-SonarQube` task prior to the reports being generated, then the working directory changes before the `Finalise-SonarQube` task runs. The result is that the SonarQube upload looks in the wrong path when it is time to upload the reports.

By using the absolute path for these reports, the change in working directory does not affect the report upload.

## Testing

1. Set the SonarQube environment variables:
    + SONARQUBE_URL
    + SONARQUBE_ID
    + SONARQUBE_TOKEN
2. Patch the recipe tool with the changes from this PR
3. Run the build:
`.\build.bat --verbosity=diagnostic --target=CI --testExecutionType=none --shouldRunAnalyze=false --shouldRunIlMerge=false --shouldObfuscateOutputAssemblies=false --shouldRunChocolatey=false --shouldRunNuGet=false --shouldRunSonarQube=true --shouldRunDependencyCheck=true`
4. See that there are no errors about the reports not being found and that they are available withing the SonarQube interface
5. 
### Operating Systems Testing

N/A

## Change Types Made

* [X] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #127
Task ENGTASKS-3098