### PR TITLE
(#130) Install PowerShell Module to Current User instead of System

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/install-module.ps1
+++ b/Chocolatey.Cake.Recipe/Content/install-module.ps1
@@ -30,5 +30,18 @@ if (Get-Module -ListAvailable -FullyQualifiedName $FullyQualifiedName) {
 }
 else {
     Write-Host "Install Module $ModuleName with version $RequiredVersion..."
-    Install-Module -Name $ModuleName -RequiredVersion $RequiredVersion -Force
+    # Bootstrap PowerShell Get
+    if (-not (Get-PackageProvider NuGet -ErrorAction Ignore)) {
+        Write-Host "Installing NuGet package provider"
+        Install-PackageProvider NuGet -MinimumVersion 2.8.5.201 -ForceBootstrap -Force -Scope CurrentUser
+    }
+
+    if (-not (Get-InstalledModule PowerShellGet -MinimumVersion 2.0 -MaximumVersion 2.99 -ErrorAction Ignore)) {
+        Install-Module PowerShellGet -MaximumVersion 2.99 -Force -AllowClobber -Scope CurrentUser
+        Remove-Module PowerShellGet -Force
+        Import-Module PowerShellGet -MinimumVersion 2.0 -Force
+        Import-PackageProvider -Name PowerShellGet -MinimumVersion 2.0 -Force
+    }
+
+    Install-Module -Name $ModuleName -RequiredVersion $RequiredVersion -Force -Scope CurrentUser
 }


### PR DESCRIPTION
## Description Of Changes

Update the code that installs the PSScriptAnalyzer module to ensure the NuGet Package Provider is installed and correctly loaded for the CurrentUser. This ensures the user running the build does not need to be running as an administrator, nor do they need to already have the NuGet Package Provider installed and up to date.

## Motivation and Context

If a user has not previously installed Modules, they may not be able to use the Cake Recipe file as it may fail to install modules.

## Testing

1. Use the Vagrantfile in the Chocolatey/choco repository to stand up a fresh development environment.
2. Run `build.bat` without being elevated from the chocolatey/choco repository.
3. Note that it fails to install the PowerShell Script Analyzer module.
4. Replace the `install-module.ps1` file in the `tools/Chocolatey.Cake.Recipe.0.26.3` directory with the one from this PR branch.
5. Run `build.bat` without being elevated again.
6. Note that it completes the build successfully.

### Operating Systems Testing

Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

- Fixes #130 
