### PR TITLE
(#142) Skip PSSA analysis when there are no files (Script or Module) to analyze

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/run-psscriptanalyzer.ps1
+++ b/Chocolatey.Cake.Recipe/Content/run-psscriptanalyzer.ps1
@@ -73,48 +73,58 @@ $modules = Get-ChildItem -Path $AnalyzePath -Filter "*.psm1" -Recurse | ForEach-
     }
 }
 
-Write-Output "Analyzing module files..."
+if ($null -ne $modules) {
+    Write-Output "Analyzing module files..."
 
-$records = Start-Job -ArgumentList $modules, $SettingsPath {
-    Param(
-        $modules,
-        $SettingsPath
-    )
-    $modules | Invoke-ScriptAnalyzer -Settings $SettingsPath | Select-Object RuleName, ScriptPath, Line, Message 
-} | Wait-Job | Receive-Job
+    $records = Start-Job -ArgumentList $modules, $SettingsPath {
+        Param(
+            $modules,
+            $SettingsPath
+        )
+        $modules | Invoke-ScriptAnalyzer -Settings $SettingsPath | Select-Object RuleName, ScriptPath, Line, Message 
+    } | Wait-Job | Receive-Job
 
-if (-not ($null -EQ $records)) {
-    Write-Output "Violations found in Module Files..."
-    $records | Format-List | Out-String
+    if (-not ($null -EQ $records)) {
+        Write-Output "Violations found in Module Files..."
+        $records | Format-List | Out-String
 
-    Write-Output $OutputPath
+        Write-Output $OutputPath
 
-    Write-Output "Writing violations to output file..."
-    $records | ConvertTo-SARIF -FilePath "$OutputPath\modules.sarif"
+        Write-Output "Writing violations to output file..."
+        $records | ConvertTo-SARIF -FilePath "$OutputPath\modules.sarif"
+    }
+    else {
+        Write-Output "No rule violations found in Module Files."
+    }
 }
 else {
-    Write-Output "No rule violations found in Module Files."
+    Write-Output "No Module Files to analyze"
 }
 
-Write-Output "Analyzing script files..."
+if ($null -ne $scripts) {
+    Write-Output "Analyzing script files..."
 
-$records = Start-Job -ArgumentList $Scripts, $SettingsPath {
-    Param(
-        $Scripts,
-        $SettingsPath
-    )
-    $Scripts | Invoke-ScriptAnalyzer -Settings $SettingsPath | Select-Object RuleName, ScriptPath, Line, Message 
-} | Wait-Job | Receive-Job
+    $records = Start-Job -ArgumentList $Scripts, $SettingsPath {
+        Param(
+            $Scripts,
+            $SettingsPath
+        )
+        $Scripts | Invoke-ScriptAnalyzer -Settings $SettingsPath | Select-Object RuleName, ScriptPath, Line, Message 
+    } | Wait-Job | Receive-Job
 
-if (-not ($null -EQ $records)) {
-    Write-Output "Violations found in Script Files..."
-    $records | Format-List | Out-String
+    if (-not ($null -EQ $records)) {
+        Write-Output "Violations found in Script Files..."
+        $records | Format-List | Out-String
 
-    Write-Output "Writing violations to output file..."
-    $records | ConvertTo-SARIF -FilePath "$OutputPath\scripts.sarif"
+        Write-Output "Writing violations to output file..."
+        $records | ConvertTo-SARIF -FilePath "$OutputPath\scripts.sarif"
+    }
+    else {
+        Write-Output "No rule violations found in Script Files."
+    }
 }
 else {
-    Write-Output "No rule violations found in Script Files."
+    Write-Output "No Script Files to analyze"
 }
 
 Write-Output "Analyzing complete."


### PR DESCRIPTION
## Description Of Changes

This PR adds a check to determine if there are any Module or Script files to be analyzed before proceeding to attempt to pass a potentially NULL variable to PSScriptAnalyzer.

## Motivation and Context

The Chocolatey GUI Licensed project includes script files but not modules files which was causing it's build to fail due to the resulting attempt to analyze a NULL path resulting in the error message is:

`Cannot validate argument on parameter 'Path'. The argument is null. Provide a valid value for the argument, and then try running the command again.`

## Testing

This has been tested on a non-production build agent by manually editing the `run-psscriptanalyzer.ps1` script and re-running the build.

### Operating Systems Testing

Windows Server 2019

## Change Types Made

* [X] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #142