### PR TITLE
(#145) Enable skipping of Yarn analysis

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/dependencyCheck.cake
+++ b/Chocolatey.Cake.Recipe/Content/dependencyCheck.cake
@@ -46,6 +46,15 @@ BuildParameters.Tasks.DependencyCheckTask = Task("Dependency-Check")
 
     DeleteFile(BuildParameters.RootDirectoryPath.CombineWithFilePath("dependency-check.zip"));
 
+    if (ToolSettings.DependencyCheckDisableYarnAudit)
+    {
+        ReplaceTextInFiles(
+            BuildParameters.RootDirectoryPath.Combine("tools/DependencyCheck.Runner.Tool.3.2.1/tools/bin").CombineWithFilePath("dependency-check.bat").ToString(), 
+            "org.owasp.dependencycheck.App %CMD_LINE_ARGS%",
+            "org.owasp.dependencycheck.App --disableYarnAudit %CMD_LINE_ARGS%"
+        );
+    };
+
     var DependencyCheckSettings = new DependencyCheckSettings {
         Project = BuildParameters.ProductName,
         Scan    = BuildParameters.SourceDirectoryPath.FullPath,

--- a/Chocolatey.Cake.Recipe/Content/toolsettings.cake
+++ b/Chocolatey.Cake.Recipe/Content/toolsettings.cake
@@ -27,6 +27,7 @@ public static class ToolSettings
     public static FilePath EazfuscatorToolLocation { get; private set; }
     public static string AmazonLambdaGlobalTool { get; private set; }
     public static string DependencyCheckTool { get; private set; }
+    public static bool DependencyCheckDisableYarnAudit { get; private set; }
     public static string DotNetFormatGlobalTool { get; private set; }
     public static string GitVersionGlobalTool { get; private set; }
     public static string GitVersionTool { get; private set; }
@@ -109,7 +110,8 @@ public static class ToolSettings
         List<string> scriptAnalyzerExcludePaths = null,
         string testCoverageExcludeByAttribute = null,
         string testCoverageExcludeByFile = null,
-        string testCoverageFilter = null
+        string testCoverageFilter = null,
+        bool dependencyCheckDisableYarnAudit = false
     )
     {
         context.Information("Setting up tools...");
@@ -124,6 +126,13 @@ public static class ToolSettings
         TestCoverageExcludeByAttribute = testCoverageExcludeByAttribute ?? "*.ExcludeFromCodeCoverage*";
         TestCoverageExcludeByFile = testCoverageExcludeByFile ?? "*/*Designer.cs;*/*.g.cs;*/*.g.i.cs";
         TestCoverageFilter = testCoverageFilter ?? string.Format("+[{0}*]* +[{1}*]* -[*.tests]* -[*.Tests]*", BuildParameters.Title, BuildParameters.Title.ToLowerInvariant());
+
+        DependencyCheckDisableYarnAudit = dependencyCheckDisableYarnAudit;
+        
+        if (context.HasArgument("dependencyCheckDisableYarnAudit"))
+        {
+            DependencyCheckDisableYarnAudit = context.Argument<bool>("dependencyCheckDisableYarnAudit");
+        }
 
         // We only use MSBuild when running on Windows. Elsewhere, we use XBuild when required. As a result,
         // we only need to detect the correct version of MSBuild when running on WIndows, and when it hasn't


### PR DESCRIPTION
## Description Of Changes

This PR enables disabling the Dependency-Check Yarn Audit analysis as part of the Dependency-Check task. Due to the Dependency-Check Cake addin being out of date, this is achieved by injecting the required switch into the `dependency-check.bat` when a new tool setting, dependencyCheckDisableYarnAudit, is set to `true`.

## Motivation and Context

Dependency-Check occasionally triggers Yarn analysis when it isn't needed and results in the Dependency-Check failing. By disabling this analysis, it allows the Dependency-Check, and build in general, to complete successfully.

## Testing

1. Clone a project that triggers Yarn Analysis
1. Set the SonarQube environment variables:
    + SONARQUBE_URL
    + SONARQUBE_ID
    + SONARQUBE_TOKEN
1. Patch the recipe tool with the changes from this PR
1. Run the build:
  `.\build.bat --verbosity=diagnostic --target=CI --testExecutionType=none --shouldRunAnalyze=false --shouldRunIlMerge=false --shouldObfuscateOutputAssemblies=false --shouldRunChocolatey=false --shouldRunNuGet=false --shouldRunSonarQube=true --shouldRunDependencyCheck=true`
1. See that build runs and that Yarn Analysis was triggered.
1. Re-run the build adding `--dependencyCheckDisableYarnAudit=true` 
1. See that the build runs and that Yarn Analysis was skipped (n.b. there is no output saying it was skipped, but it will be missing from the list of audits executed as they are executed.) 

### Operating Systems Testing

Windows Server 2019

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

* Fixes #145 
* ClickUp: ENGTASKS-3098