### PR TITLE
(#147) Update Authenticode signing certificate subject name and allow setting it via an environment variable

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -477,7 +477,7 @@ public static class BuildParameters
         CertificateAlgorithm = context.EnvironmentVariable("CERT_ALGORITHM") ?? "Sha256";
         CertificateFilePath = context.EnvironmentVariable("CHOCOLATEY_OFFICIAL_CERT") ?? "";
         CertificatePassword = context.EnvironmentVariable("CHOCOLATEY_OFFICIAL_CERT_PASSWORD") ?? "";
-        CertificateSubjectName = certificateSubjectName ?? "Chocolatey Software, Inc.";
+        CertificateSubjectName = context.EnvironmentVariable("CHOCOLATEY_OFFICIAL_CERT_SUBJECT_NAME") ?? certificateSubjectName ?? "Chocolatey Software, Inc";
         CertificateTimestampUrl = context.EnvironmentVariable("CERT_TIMESTAMP_URL") ?? "http://timestamp.digicert.com";
         ChocolateyNupkgGlobbingPattern = chocolateyNupkgGlobbingPattern;
         ChocolateyNuspecGlobbingPattern = chocolateyNuspecGlobbingPattern;


### PR DESCRIPTION
## Description Of Changes

This PR updates the default subject name for the Authenticode signing certificate from `Chocolatey Software, Inc.` to `Chocolatey Software, Inc` and also enables overriding this subject name via an environment variable.

## Motivation and Context

During the renewal of the Authenticode signing certificate, the subject name changed slightly, and so signing fails due to not being able to find the matching certificate.

This change necessitates updating the version of this recipe used in projects, to avoid this situation in the future the option of providing an environment variable was introduced.

## Testing

_I'm not 100% sure on how to best test this_

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #147
