### PR TITLE
(#149) Switch to only signing when required

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -570,9 +570,9 @@ public class Builder
         BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Configuration-Builder");
         BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Obfuscate-Assemblies");
         BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Sign-Assemblies");
-        BuildParameters.Tasks.CreateNuGetPackagesTask.IsDependentOn("Sign-PowerShellScripts");
+        BuildParameters.Tasks.CreateNuGetPackagesTask.IsDependentOn("Verify-PowerShellScripts");
         BuildParameters.Tasks.CreateNuGetPackagesTask.IsDependentOn("Sign-Assemblies");
-        BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Sign-PowerShellScripts");
+        BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Verify-PowerShellScripts");
         BuildParameters.Tasks.SignMsisTask.IsDependentOn("Sign-Assemblies");
         BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn(prefix + "Build");
         BuildParameters.Tasks.ObfuscateAssembliesTask.IsDependeeOf("Sign-Assemblies");

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -107,6 +107,7 @@ public static class BuildParameters
     public static Func<List<PSScriptAnalyzerSettings>> GetPSScriptAnalyzerSettings { get; private set; }
     public static Func<FilePathCollection> GetMsisToSign { get; private set; }
     public static Func<FilePathCollection> GetProjectsToPack { get; private set; }
+    public static Func<FilePathCollection> GetScriptsToVerify { get; private set; }
     public static Func<FilePathCollection> GetScriptsToSign { get; private set; }
     public static GitReleaseManagerCredentials GitReleaseManager { get; private set; }
     public static string IntegrationTestAssemblyFilePattern { get; private set; }
@@ -146,6 +147,7 @@ public static class BuildParameters
     public static DirectoryPath RootDirectoryPath { get; private set; }
     public static bool ShouldAuthenticodeSignMsis { get; private set; }
     public static bool ShouldAuthenticodeSignOutputAssemblies { get; private set; }
+    public static bool ShouldVerifyPowerShellScripts { get; private set; }
     public static bool ShouldAuthenticodeSignPowerShellScripts { get; private set; }
     public static bool ShouldBuildMsi { get; private set; }
     public static bool ShouldBuildNuGetSourcePackage { get; private set; }
@@ -280,6 +282,7 @@ public static class BuildParameters
         context.Information("RestorePackagesDirectory: {0}", RestorePackagesDirectory);
         context.Information("ShouldAuthenticodeSignMsis: {0}", BuildParameters.ShouldAuthenticodeSignMsis);
         context.Information("ShouldAuthenticodeSignOutputAssemblies: {0}", BuildParameters.ShouldAuthenticodeSignOutputAssemblies);
+        context.Information("ShouldVerifyPowerShellScripts: {0}", BuildParameters.ShouldVerifyPowerShellScripts);
         context.Information("ShouldAuthenticodeSignPowerShellScripts: {0}", BuildParameters.ShouldAuthenticodeSignPowerShellScripts);
         context.Information("ShouldBuildMsi: {0}", BuildParameters.ShouldBuildMsi);
         context.Information("ShouldBuildNuGetSourcePackage: {0}", BuildParameters.ShouldBuildNuGetSourcePackage);
@@ -360,6 +363,7 @@ public static class BuildParameters
         Func<List<PSScriptAnalyzerSettings>> getPSScriptAnalyzerSettings = null,
         Func<FilePathCollection> getMsisToSign = null,
         Func<FilePathCollection> getProjectsToPack = null,
+        Func<FilePathCollection> getScriptsToVerify = null,
         Func<FilePathCollection> getScriptsToSign = null,
         string integrationTestAssemblyFilePattern = null,
         string integrationTestAssemblyProjectPattern = null,
@@ -391,6 +395,7 @@ public static class BuildParameters
         DirectoryPath rootDirectoryPath = null,
         bool shouldAuthenticodeSignMsis = true,
         bool shouldAuthenticodeSignOutputAssemblies = true,
+        bool shouldVerifyPowerShellScripts = true,
         bool shouldAuthenticodeSignPowerShellScripts = true,
         bool shouldBuildMsi = false,
         bool shouldBuildNuGetSourcePackage = false,
@@ -495,6 +500,7 @@ public static class BuildParameters
         GetPSScriptAnalyzerSettings = getPSScriptAnalyzerSettings;
         GetMsisToSign = getMsisToSign;
         GetProjectsToPack = getProjectsToPack;
+        GetScriptsToVerify = getScriptsToVerify;
         GetScriptsToSign = getScriptsToSign;
         GitReleaseManager = GetGitReleaseManagerCredentials(context);
         IntegrationTestAssemblyFilePattern = integrationTestAssemblyFilePattern ?? "/**/*[tT]ests.[iI]ntegration.dll";
@@ -540,6 +546,13 @@ public static class BuildParameters
         if (context.HasArgument("shouldAuthenticodeSignOutputAssemblies"))
         {
             ShouldAuthenticodeSignOutputAssemblies = context.Argument<bool>("shouldAuthenticodeSignOutputAssemblies");
+        }
+
+        ShouldVerifyPowerShellScripts = shouldVerifyPowerShellScripts;
+
+        if (context.HasArgument("shouldVerifyPowerShellScripts"))
+        {
+            ShouldVerifyPowerShellScripts = context.Argument<bool>("shouldVerifyPowerShellScripts");
         }
 
         ShouldAuthenticodeSignPowerShellScripts = shouldAuthenticodeSignPowerShellScripts;

--- a/Chocolatey.Cake.Recipe/Content/paths.cake
+++ b/Chocolatey.Cake.Recipe/Content/paths.cake
@@ -49,6 +49,8 @@ public class BuildPaths
         var chocolateyPackagesOutputDirectory = packagesDirectory + "/Chocolatey";
 
         var dependencyCheckReportsDirectory = buildDirectoryPath + "/DependencyCheckReports";
+        
+        var signedFilesDirectory = buildDirectoryPath + "/SignedFiles";
 
         // Files
         var dotNetFormatOutputFilePath = ((DirectoryPath)testResultsDirectory).CombineWithFilePath("dotnet-format.json");
@@ -84,7 +86,8 @@ public class BuildPaths
             chocolateyPackagesOutputDirectory,
             packagesDirectory,
             environmentSettingsDirectory,
-            dependencyCheckReportsDirectory
+            dependencyCheckReportsDirectory,
+            signedFilesDirectory
             );
 
         var buildFiles = new BuildFiles(
@@ -176,6 +179,7 @@ public class BuildDirectories
     public DirectoryPath Packages { get; private set; }
     public DirectoryPath EnvironmentSettings { get; private set; }
     public DirectoryPath DependencyCheckReports { get; private set; }
+    public DirectoryPath SignedFiles { get; private set; }
     public ICollection<DirectoryPath> ToClean { get; private set; }
 
     public BuildDirectories(
@@ -199,7 +203,8 @@ public class BuildDirectories
         DirectoryPath chocolateyPackages,
         DirectoryPath packages,
         DirectoryPath environmentSettings,
-        DirectoryPath dependencyCheckReports
+        DirectoryPath dependencyCheckReports,
+        DirectoryPath signedFiles
         )
     {
         Build = build;
@@ -222,6 +227,7 @@ public class BuildDirectories
         ChocolateyPackages = chocolateyPackages;
         EnvironmentSettings = environmentSettings;
         DependencyCheckReports = dependencyCheckReports;
+        SignedFiles = signedFiles;
         Packages = packages;
 
         ToClean = new[] {

--- a/Chocolatey.Cake.Recipe/Content/tasks.cake
+++ b/Chocolatey.Cake.Recipe/Content/tasks.cake
@@ -78,6 +78,7 @@ public class BuildTasks
     public CakeTaskBuilder StrongNameSignerTask { get; set; }
 
     // Signing Tasks
+    public CakeTaskBuilder VerifyPowerShellScriptsTask { get; set; }
     public CakeTaskBuilder SignPowerShellScriptsTask { get; set; }
     public CakeTaskBuilder SignAssembliesTask { get; set; }
     public CakeTaskBuilder SignMsisTask { get; set; }

--- a/Chocolatey.Cake.Recipe/Content/verify-powershell.ps1
+++ b/Chocolatey.Cake.Recipe/Content/verify-powershell.ps1
@@ -1,0 +1,46 @@
+# Copyright © 2024 Chocolatey Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+#
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[cmdletBinding()]
+Param(
+    [Parameter()]
+    [String[]]
+    $ScriptsToVerify
+)
+
+$AllScriptsVerified = $true
+
+Write-Output ""
+Write-Output "========== Verifying PowerShell Scripts =========="
+Write-Output ""
+
+foreach ($ScriptToVerify in $ScriptsToVerify) {
+    $ExistingSig = Get-AuthenticodeSignature -FilePath $ScriptToVerify
+
+    if ($ExistingSig.Status -ne 'Valid' -or $ExistingSig.SignerCertificate.Issuer -notmatch 'DigiCert' -or $ExistingSig.SignerCertificate.NotAfter -lt [datetime]::Now) {
+        $AllScriptsVerified = $false
+        Write-Output "Script file '$ScriptToVerify' contains an invalid signature, which must be corrected before build can succeed."
+    } else {
+        Write-Output "Script file '$ScriptToVerify' does not need signing, current signature is valid."
+    }
+}
+
+Write-Output ""
+Write-Output "========== Verification Complete =========="
+Write-Output ""
+
+if ($AllScriptsVerified -eq $false) {
+    throw "At least one PowerShell script had an invalid signature. Check output for details."
+}


### PR DESCRIPTION
## Description Of Changes

This commit addresses this need by changing the DAG to use a new Verify-PowerShellScipts task, rather than the Sign-PowerShellScripts task.  The latter is still available to call directly, when required, but only when a valid certificate is in place.

Supporting parameters and build directories have been created, to allow control over what the tasks due, including the ability to skip the verification step, using the --shouldVerifyPowerShellScripts command line argument.

A new verify-powershell.ps1 file has been added to check the list of incoming files, and the sign-powershell.ps1 has been updated to only sign when the current signature is invalid.  To aid with getting the signed files added to back into the repository, the signed files are uploaded as artifacts of the build.

## Motivation and Context

We don't want to sign files when we don't need to.  Going forward, PowerShell scripts are going to be signed when they are committed to the repository and only re-signed when required.

## Testing

This will be a tricky one to test 😢 

This will need to be tested in conjunction with this [PR](https://github.com/chocolatey/choco/pull/3441), and also in conjunction with a new build configuration for calling the updated Sign-PowerShellScripts task.

Happy to jump on a quick call to discuss further.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #149