### PR TITLE
(#155) Keep directory structure for signed PowerShell scripts

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/sign.cake
+++ b/Chocolatey.Cake.Recipe/Content/sign.cake
@@ -97,10 +97,11 @@ BuildParameters.Tasks.SignPowerShellScriptsTask = Task("Sign-PowerShellScripts")
                 });
         }
 
-        foreach (var signedFile in GetFiles(BuildParameters.Paths.Directories.SignedFiles + "/**/*"))
-        {
-            BuildParameters.BuildProvider.UploadArtifact(signedFile);
-        }
+        var files = GetFiles(BuildParameters.Paths.Directories.SignedFiles + "/**/*") - GetFiles(BuildParameters.Paths.Directories.SignedFiles + "/**/*.zip");
+        var destination = BuildParameters.Paths.Directories.SignedFiles.CombineWithFilePath("SignedFiles.zip");
+        Zip(BuildParameters.Paths.Directories.SignedFiles, destination, files);
+
+        BuildParameters.BuildProvider.UploadArtifact(destination);
     }
     else
     {


### PR DESCRIPTION
## Description Of Changes

This updates how scripts that are signed will be handled, by using the
same directory structure in the output folder as is relative for the now
new parameter for a Root Folder. It also updates how the artifacts are created and uploaded by first create a zip archive of the files hile preserving the directory structure, and then upload only the zip archive.

## Motivation and Context

To allow multiple files with the same name to be signed, without the files overwriting eachother, as well as making it easier in the future when we have signed scripts and only need to download a single file that can be extracted immediately to the correct locations.

## Testing

This has been tested manually by running the signing process locally, while commenting out the necessary parts that would fail if no signing keys are present.
The verification was that everything was copied to the correct directory structure, a zip archive was created with the same directory structure expected and it uploaded it to the artifacts directory.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #155
