### PR TITLE
(#159) Wix package is required for restore

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -92,7 +92,7 @@ BuildParameters.Tasks.RestoreTask = Task("Restore")
 BuildParameters.Tasks.DotNetRestoreTask = Task("DotNetRestore")
     .WithCriteria(() => BuildParameters.IsDotNetBuild, "Skipping since running DotNet related tasks hasn't been selected in the recipe.cake file.")
     .IsDependentOn("Clean")
-    .Does(() =>
+    .Does(() => RequireTool(ToolSettings.WixTool, () =>
 {
     var msBuildSettings = new DotNetCoreMSBuildSettings()
                             .WithProperty("Version", BuildParameters.Version.SemVersion)


### PR DESCRIPTION
## Description Of Changes

Resolve error in build when restore task is run due to wix.props file not being found.

## Motivation and Context
<!-- Why is this change necessary and under what context is it being done -->

## Testing

### Operating Systems Testing

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #159