### PR TITLE
(#162) Rework prerelease substring

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/gitversion.cake
+++ b/Chocolatey.Cake.Recipe/Content/gitversion.cake
@@ -131,19 +131,21 @@ public class BuildVersion
 
         prerelease = assertedVersions.PreReleaseLabel;
 
-        // Having a pre-release label of greater than 10 characters can cause problems when trying to run choco pack.
-        // Since we typically only see this when building a local feature branch, or a PR, let's just trim it down to
-        // the 10 character limit, and move on.
-        if (prerelease.Length > 10)
-        {
-            prerelease = prerelease.Replace("-", string.Empty).Substring(0, 10);
-        }
+        prerelease = prerelease.Replace("-", string.Empty);
 
         // Chocolatey doesn't support a prerelease that starts with a digit.
         // If we see a digit here, merely replace it with an `a` to get around this.
         if (System.Text.RegularExpressions.Regex.Match(prerelease, @"^\d.*$").Success)
         {
-            prerelease = string.Format("a{0}", prerelease.Substring(1,9));
+            prerelease = string.Format("a{0}", prerelease);
+        }
+
+        // Having a pre-release label of greater than 10 characters can cause problems when trying to run choco pack.
+        // Since we typically only see this when building a local feature branch, or a PR, let's just trim it down to
+        // the 10 character limit, and move on.
+        if (prerelease.Length > 10)
+        {
+            prerelease = prerelease.Substring(0, 10);
         }
 
         sha = assertedVersions.Sha.Substring(0,8);


### PR DESCRIPTION
## Description Of Changes

This reworks the way we handle the prerelease version. Before if you had a less than 9 character branch that started with a number, we would prepend the letter a, then take the first 9 characters. This would result in an exception. Further, if you had a greater than 10 character branch name, we would remove the `-` in it and take the first 10 characters from that. With an 11 character branch with 2 `-` this would be an error as the max length to take is 9. Instead now we will work just on the part of the string we're fixing, with the max length being the last one handled.

## Motivation and Context

Prevent some edge cases where the build fails.

## Testing

1. Copy the files from this PR into the correct place in the Chocolatey/choco repository.
2. Run the build there for branches named: `3465-msi`, `gh-3465-msi`, `gh-3465-msi1`.
3. Note that the build now succeeds.

### Operating Systems Testing

- Windows 10

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v2 compatibility checked?

## Related Issue

Fixes #162