### PR TITLE
(GH-171)(ENGTASKS-4195) Enable Central NVD Vulnerability Data Database and Bump DepencencyCheck Version

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/credentials.cake
+++ b/Chocolatey.Cake.Recipe/Content/credentials.cake
@@ -49,6 +49,30 @@ public class MastodonCredentials
     }
 }
 
+public class DependencyCheckNvdCredentials
+{
+    public string ApiKey { get; private set; }
+
+    public DependencyCheckNvdCredentials(string apiKey)
+    {
+        ApiKey = apiKey;
+    }
+}
+
+public class DependencyCheckDbCredentials
+{
+    public string ConnectionString { get; private set; }
+    public string UserName { get; private set; }
+    public string Password { get; private set; }
+
+    public DependencyCheckDbCredentials(string connectionString, string userName, string password)
+    {
+        ConnectionString = connectionString;
+        UserName = userName;
+        Password = password;
+    }
+}
+
 public class SlackCredentials
 {
     public string Channel { get; private set; }
@@ -154,6 +178,22 @@ public static MastodonCredentials GetMastodonCredentials(ICakeContext context)
     return new MastodonCredentials(
         context.EnvironmentVariable(Environment.MastodonTokenVariable),
         context.EnvironmentVariable(Environment.MastodonHostNameVariable)
+    );
+}
+
+public static DependencyCheckNvdCredentials GetDependencyCheckNvdCredentials(ICakeContext context)
+{
+    return new DependencyCheckNvdCredentials(
+        context.EnvironmentVariable(Environment.DependencyCheckNvdApiKeyVariable)
+    );
+}
+
+public static DependencyCheckDbCredentials GetDependencyCheckDbCredentials(ICakeContext context)
+{
+    return new DependencyCheckDbCredentials(
+        context.EnvironmentVariable(Environment.DependencyCheckDbConnectionStringVariable),
+        context.EnvironmentVariable(Environment.DependencyCheckDbUserVariable),
+        context.EnvironmentVariable(Environment.DependencyCheckDbPasswordVariable)
     );
 }
 

--- a/Chocolatey.Cake.Recipe/Content/dependencyCheck.cake
+++ b/Chocolatey.Cake.Recipe/Content/dependencyCheck.cake
@@ -22,7 +22,7 @@ BuildParameters.Tasks.DependencyCheckTask = Task("Dependency-Check")
     .Does(() => RequireTool(ToolSettings.DependencyCheckTool, () =>
 {
     DownloadFile(
-        "https://github.com/jeremylong/DependencyCheck/releases/download/v8.2.1/dependency-check-8.2.1-release.zip",
+        "https://github.com/jeremylong/DependencyCheck/releases/download/v12.0.1/dependency-check-12.0.1-release.zip",
         BuildParameters.RootDirectoryPath.CombineWithFilePath("dependency-check.zip")
     );
 
@@ -49,7 +49,7 @@ BuildParameters.Tasks.DependencyCheckTask = Task("Dependency-Check")
     if (ToolSettings.DependencyCheckDisableYarnAudit)
     {
         ReplaceTextInFiles(
-            BuildParameters.RootDirectoryPath.Combine("tools/DependencyCheck.Runner.Tool.3.2.1/tools/bin").CombineWithFilePath("dependency-check.bat").ToString(), 
+            BuildParameters.RootDirectoryPath.Combine("tools/DependencyCheck.Runner.Tool.3.2.1/tools/bin").CombineWithFilePath("dependency-check.bat").ToString(),
             "org.owasp.dependencycheck.App %CMD_LINE_ARGS%",
             "org.owasp.dependencycheck.App --disableYarnAudit %CMD_LINE_ARGS%"
         );

--- a/Chocolatey.Cake.Recipe/Content/dependencyCheck.cake
+++ b/Chocolatey.Cake.Recipe/Content/dependencyCheck.cake
@@ -55,11 +55,31 @@ BuildParameters.Tasks.DependencyCheckTask = Task("Dependency-Check")
         );
     };
 
+    if (!string.IsNullOrEmpty(BuildParameters.DependencyCheckNvdApiKey))
+    {
+        ReplaceTextInFiles(
+            BuildParameters.RootDirectoryPath.Combine("tools/DependencyCheck.Runner.Tool.3.2.1/tools/bin").CombineWithFilePath("dependency-check.bat").ToString(),
+            "%CMD_LINE_ARGS%",
+            string.Format("--nvdApiKey {0} %CMD_LINE_ARGS%", BuildParameters.DependencyCheckNvdApiKey)
+        );
+    };
+
     var DependencyCheckSettings = new DependencyCheckSettings {
         Project = BuildParameters.ProductName,
         Scan    = BuildParameters.SourceDirectoryPath.FullPath,
         Format  = "ALL",
         Out     = BuildParameters.Paths.Directories.DependencyCheckReports.FullPath
+    };
+
+    if (!string.IsNullOrEmpty(BuildParameters.DependencyCheckDb.ConnectionString) &&
+        !string.IsNullOrEmpty(BuildParameters.DependencyCheckDb.UserName) &&
+        !string.IsNullOrEmpty(BuildParameters.DependencyCheckDb.Password))
+    {
+        DependencyCheckSettings.ConnectionString   = BuildParameters.DependencyCheckDb.ConnectionString;
+        DependencyCheckSettings.DatabaseUser       = BuildParameters.DependencyCheckDb.UserName;
+        DependencyCheckSettings.DatabasePassword   = BuildParameters.DependencyCheckDb.Password;
+        DependencyCheckSettings.DatabaseDriverName = BuildParameters.DependencyCheckDbDriverName;
+        DependencyCheckSettings.DatabaseDriverPath = BuildParameters.Paths.Files.DependencyCheckDbDriverPath.ToString();
     };
 
     DependencyCheck(DependencyCheckSettings);

--- a/Chocolatey.Cake.Recipe/Content/environment.cake
+++ b/Chocolatey.Cake.Recipe/Content/environment.cake
@@ -16,6 +16,11 @@
 public static class Environment
 {
     public static string DefaultPushSourceUrlVariable { get; private set; }
+    public static string DependencyCheckDbConnectionStringVariable { get; private set; }
+    public static string DependencyCheckDbDriverNameVariable { get; private set; }
+    public static string DependencyCheckDbPasswordVariable { get; private set; }
+    public static string DependencyCheckDbUserVariable { get; private set; }
+    public static string DependencyCheckNvdApiKeyVariable { get; private set; }
     public static string DiscordWebHookUrlVariable { get; private set; }
     public static string DiscordUserNameVariable { get; private set; }
     public static string DiscordAvatarUrlVariable { get; private set; }
@@ -38,6 +43,11 @@ public static class Environment
 
     public static void SetVariableNames(
         string defaultPushSourceUrlVariable = null,
+        string dependencyCheckDbConnectionStringVariable = null,
+        string dependencyCheckDbDriverNameVariable = null,
+        string dependencyCheckDbPasswordVariable = null,
+        string dependencyCheckDbUserVariable = null,
+        string dependencyCheckNvdApiKeyVariable = null,
         string discordWebHookUrlVariable = null,
         string discordUserNameVariable = null,
         string discordAvatarUrlVariable = null,
@@ -59,6 +69,11 @@ public static class Environment
         string dockerServerVariable = null)
     {
         DefaultPushSourceUrlVariable = defaultPushSourceUrlVariable ?? "NUGETDEVPUSH_SOURCE";
+        DependencyCheckDbConnectionStringVariable = dependencyCheckDbConnectionStringVariable ?? "DEPENDENCYCHECK_DB_CONNECTIONSTRING";
+        DependencyCheckDbDriverNameVariable = dependencyCheckDbDriverNameVariable ?? "DEPENDENCYCHECK_DB_DRIVERNAME";
+        DependencyCheckDbPasswordVariable = dependencyCheckDbPasswordVariable ?? "DEPENDENCYCHECK_DB_PASSWORD";
+        DependencyCheckDbUserVariable = dependencyCheckDbUserVariable ?? "DEPENDENCYCHECK_DB_USER";
+        DependencyCheckNvdApiKeyVariable = dependencyCheckNvdApiKeyVariable ?? "DEPENDENCYCHECK_NVD_API_KEY";
         DiscordWebHookUrlVariable = discordWebHookUrlVariable ?? "DISCORD_WEBHOOKURL";
         DiscordUserNameVariable = discordUserNameVariable ?? "DISCORD_USERNAME";
         DiscordAvatarUrlVariable = discordAvatarUrlVariable ?? "DISCORD_AVATARURL";

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -95,6 +95,9 @@ public static class BuildParameters
     public static string ChocolateyNupkgGlobbingPattern { get; private set; }
     public static string ChocolateyNuspecGlobbingPattern { get; private set; }
     public static string Configuration { get; private set; }
+    public static DependencyCheckDbCredentials DependencyCheckDb { get; private set; }
+    public static string DependencyCheckDbDriverName { get; private set; }
+    public static string DependencyCheckNvdApiKey { get; private set; }
     public static string DeploymentEnvironment { get; private set; }
     public static string DevelopBranchName { get; private set; }
     public static DiscordCredentials Discord { get; private set; }
@@ -247,6 +250,7 @@ public static class BuildParameters
         context.Information("ChocolateyNupkgGlobbingPattern: {0}", ChocolateyNupkgGlobbingPattern);
         context.Information("ChocolateyNuspecGlobbingPattern: {0}", ChocolateyNuspecGlobbingPattern);
         context.Information("Configuration: {0}", Configuration);
+        context.Information("DependencyCheckDbDriverName: {0}", BuildParameters.DependencyCheckDbDriverName);
         context.Information("ForceContinuousIntegration: {0}", ForceContinuousIntegration);
         context.Information("IntegrationTestAssemblyFilePattern: {0}", IntegrationTestAssemblyFilePattern);
         context.Information("IntegrationTestAssemblyProjectPattern: {0}", IntegrationTestAssemblyProjectPattern);
@@ -355,6 +359,7 @@ public static class BuildParameters
         string certificateSubjectName = null,
         string chocolateyNupkgGlobbingPattern = "/**/*.nupkg",
         string chocolateyNuspecGlobbingPattern = "/**/*.nuspec",
+        string dependencyCheckDbDriverName = null,
         string developBranchName = "develop",
         Func<BuildVersion, object[]> discordMessageArguments = null,
         FilePath fullReleaseNotesFilePath = null,
@@ -488,6 +493,9 @@ public static class BuildParameters
         ChocolateyNupkgGlobbingPattern = chocolateyNupkgGlobbingPattern;
         ChocolateyNuspecGlobbingPattern = chocolateyNuspecGlobbingPattern;
         Configuration = context.Argument("configuration", "Release");
+        DependencyCheckDb = GetDependencyCheckDbCredentials(context);
+        DependencyCheckDbDriverName = dependencyCheckDbDriverName ?? context.EnvironmentVariable(Environment.DependencyCheckDbDriverNameVariable) ?? "com.microsoft.sqlserver.jdbc.SQLServerDriver";
+        DependencyCheckNvdApiKey = GetDependencyCheckNvdCredentials(context).ApiKey;
         Discord = GetDiscordCredentials(context);
         DiscordMessageArguments = discordMessageArguments ?? _defaultNotificationArguments;
         DockerCredentials = GetDockerCredentials(context);
@@ -852,7 +860,7 @@ public static class BuildParameters
         UnitTestAssemblyProjectPattern = unitTestAssemblyProjectPattern ?? "/**/*.[tT]ests/**/*.[tT]ests.csproj";
         UseChocolateyGuiStrongNameKey = useChocolateyGuiStrongNameKey;
 
-        SetBuildPaths(BuildPaths.GetPaths());
+        SetBuildPaths(BuildPaths.GetPaths(context));
 
         var branchName = BuildProvider.Repository.Branch;
         if (StringComparer.OrdinalIgnoreCase.Equals(masterBranchName, branchName))

--- a/Chocolatey.Cake.Recipe/Content/paths.cake
+++ b/Chocolatey.Cake.Recipe/Content/paths.cake
@@ -18,7 +18,7 @@ public class BuildPaths
     public BuildFiles Files { get; private set; }
     public BuildDirectories Directories { get; private set; }
 
-    public static BuildPaths GetPaths()
+    public static BuildPaths GetPaths(ICakeContext context)
     {
         // Directories
         var buildDirectoryPath             = "./code_drop";
@@ -49,7 +49,7 @@ public class BuildPaths
         var chocolateyPackagesOutputDirectory = packagesDirectory + "/Chocolatey";
 
         var dependencyCheckReportsDirectory = buildDirectoryPath + "/DependencyCheckReports";
-        
+
         var signedFilesDirectory = buildDirectoryPath + "/SignedFiles";
 
         // Files
@@ -57,6 +57,7 @@ public class BuildPaths
         var testCoverageOutputFilePath = ((DirectoryPath)testCoverageDirectory).CombineWithFilePath("OpenCover.xml");
         var solutionInfoFilePath = ((DirectoryPath)BuildParameters.SourceDirectoryPath).CombineWithFilePath("SolutionVersion.cs");
         var buildLogFilePath = ((DirectoryPath)buildDirectoryPath).CombineWithFilePath("MsBuild.log");
+        var dependencyCheckDbDriverPath = context.GetFiles("C:/Program Files/Microsoft JDBC DRIVER for SQL Server/sqljdbc_*/enu/mssql-jdbc-*.jre11.jar").FirstOrDefault();
         var dependencyCheckJsonReportFilePath = ((DirectoryPath)dependencyCheckReportsDirectory).CombineWithFilePath("dependency-check-report.json");
         var dependencyCheckHtmlReportFilePath = ((DirectoryPath)dependencyCheckReportsDirectory).CombineWithFilePath("dependency-check-report.html");
 
@@ -96,6 +97,7 @@ public class BuildPaths
             testCoverageOutputFilePath,
             solutionInfoFilePath,
             buildLogFilePath,
+            dependencyCheckDbDriverPath,
             dependencyCheckJsonReportFilePath,
             dependencyCheckHtmlReportFilePath
             );
@@ -119,6 +121,8 @@ public class BuildFiles
 
     public FilePath BuildLogFilePath { get; private set; }
 
+    public FilePath DependencyCheckDbDriverPath { get; private set; }
+
     public FilePath DependencyCheckJsonReportFilePath { get; private set; }
 
     public FilePath DependencyCheckHtmlReportFilePath { get; private set; }
@@ -129,6 +133,7 @@ public class BuildFiles
         FilePath testCoverageOutputFilePath,
         FilePath solutionInfoFilePath,
         FilePath buildLogFilePath,
+        FilePath dependencyCheckDbDriverPath,
         FilePath dependencyCheckJsonReportFilePath,
         FilePath dependencyCheckHtmlReportFilePath
         )
@@ -138,6 +143,7 @@ public class BuildFiles
         TestCoverageOutputFilePath = testCoverageOutputFilePath;
         SolutionInfoFilePath = solutionInfoFilePath;
         BuildLogFilePath = buildLogFilePath;
+        DependencyCheckDbDriverPath = dependencyCheckDbDriverPath;
         DependencyCheckJsonReportFilePath = dependencyCheckJsonReportFilePath;
         DependencyCheckHtmlReportFilePath = dependencyCheckHtmlReportFilePath;
     }


### PR DESCRIPTION
## Description Of Changes

This PR adds parameters related to configuring DependencyCheck to use a central database to cache all vulnerability data rather than needing to download it fresh on every execution (via an ephemeral agent.)

It also bumps the version of DependencyCheck that is pulled down from 8.2.1 to 12.0.1.

Database credentials, including the connection string, username, and password are bring created as a credential object.

## Motivation and Context

We were beginning to see an issue where some vulnerabilities had modern scores but not the legacy counterpart and this was causing DependencyCheck to error when generating the reports. 12.0.0 of DependencyCheck fixes this issue. 12.0.1 of DependencyCheck has also been released and so that has been pulled in so that the recipe is as up to date as possible.

Moving beyond 9.0.0 of DependencyCheck also necessitated changing how we handle the vulnerability data, as this changed from a method that was "manageable" to "ergh, this will take hours per run"

Related to this change, an API key is now recommended when downloading vulnerability data (otherwise heavy rate limits are imposed) and so a parameter for this has also been added.

The runner tool did not natively support passing through the command line argument for this API key, which was similar to a previous change for disabling Yarn analysis, and so this argument is injected into the called batch file when required.

## Testing

This recipe was built and provided to a project on a test TeamCity instance. This validated that the central vulnerability database was being used (and updated), and that the issue regarding legacy scores on vulnerabilities was resolved.

![TeamCity Success](https://github.com/user-attachments/assets/615f0faa-29a0-46b6-b4b3-dbd5b6d13b76)

![DepdendencyCheck Report](https://github.com/user-attachments/assets/2a1bb312-4954-4fc6-9cd6-26a491ac9405)

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [X] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #171 
ClickUp ENGTASKS-4195