### PR TITLE
(#134) Correct target branch for support branches

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/gitreleasemanager.cake
+++ b/Chocolatey.Cake.Recipe/Content/gitreleasemanager.cake
@@ -1,4 +1,4 @@
-// Copyright © 2022 Chocolatey Software, Inc
+// Copyright © 2025 Chocolatey Software, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,11 +25,11 @@ BuildParameters.Tasks.CreateReleaseNotesTask = Task("Create-Release-Notes")
             {
                 Milestone         = BuildParameters.Version.Milestone,
                 Name              = BuildParameters.Version.Milestone,
-                TargetCommitish   = BuildParameters.MasterBranchName,
+                TargetCommitish   = Context.Argument("target-branch", BuildParameters.MasterBranchName),
                 Prerelease        = Context.HasArgument("create-pre-release")
             };
 
-            if (settings.Prerelease)
+            if (!Context.HasArgument("target-branch") && (settings.Prerelease || BuildParameters.BranchType == BranchType.Support))
             {
                 settings.TargetCommitish = BuildParameters.BuildProvider.Repository.Branch;
             }


### PR DESCRIPTION
## Description Of Changes

This fixes an issue when Drafting release notes using GitReleaseManger
and when we are running of one of the support branches.

This change makes it so that any runs from the support branches will
set the current target branch to the branch it is running from.

## Motivation and Context

Whithout this change, the target branch will always be set to the master branch when drafting release notes, and we are running on a support branch.

## Testing

1. Go to your test github repository, and create a `support/4.x` branch.
2. Build and copy the cake scripts in the recipe repository over to the test repository.
3. Set up needed credentials to work with GRM.
4. Draft a new release using `.\build.bat --target="Create-Release-Notes"`.
5. Verify the drafted release notes are targeting the support branch.
6. Repeat 1-5 using a GitLab test repository.

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #134
