### PR TITLE
(#173) Use Product Copyright for packages

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -98,7 +98,8 @@ BuildParameters.Tasks.DotNetRestoreTask = Task("DotNetRestore")
                             .WithProperty("Version", BuildParameters.Version.SemVersion)
                             .WithProperty("AssemblyVersion", BuildParameters.Version.FileVersion)
                             .WithProperty("FileVersion",  BuildParameters.Version.FileVersion)
-                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion);
+                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
+                            .WithProperty("Copyright", BuildParameters.ProductCopyright);
 
     if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
     {
@@ -187,7 +188,8 @@ BuildParameters.Tasks.DotNetBuildTask = Task("DotNetBuild")
                             .WithProperty("Version", BuildParameters.Version.SemVersion)
                             .WithProperty("AssemblyVersion", BuildParameters.Version.FileVersion)
                             .WithProperty("FileVersion",  BuildParameters.Version.FileVersion)
-                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion);
+                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
+                            .WithProperty("Copyright", BuildParameters.ProductCopyright);
 
         if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
         {
@@ -346,7 +348,8 @@ public void CopyBuildOutput()
                             .WithProperty("Version", BuildParameters.Version.SemVersion)
                             .WithProperty("AssemblyVersion", BuildParameters.Version.FileVersion)
                             .WithProperty("FileVersion",  BuildParameters.Version.FileVersion)
-                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion);
+                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
+                            .WithProperty("Copyright", BuildParameters.ProductCopyright);
 
                 if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
                 {
@@ -408,7 +411,8 @@ public void CopyBuildOutput()
                             .WithProperty("Version", BuildParameters.Version.SemVersion)
                             .WithProperty("AssemblyVersion", BuildParameters.Version.FileVersion)
                             .WithProperty("FileVersion",  BuildParameters.Version.FileVersion)
-                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion);
+                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
+                            .WithProperty("Copyright", BuildParameters.ProductCopyright);
 
                 if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
                 {

--- a/Chocolatey.Cake.Recipe/Content/packages.cake
+++ b/Chocolatey.Cake.Recipe/Content/packages.cake
@@ -51,7 +51,8 @@ BuildParameters.Tasks.CreateChocolateyPackagesTask = Task("Create-Chocolatey-Pac
             AllowUnofficial = true,
             Version = BuildParameters.Version.PackageVersion,
             OutputDirectory = BuildParameters.Paths.Directories.ChocolateyPackages,
-            WorkingDirectory = BuildParameters.Paths.Directories.PublishedApplications
+            WorkingDirectory = BuildParameters.Paths.Directories.PublishedApplications,
+            Copyright = BuildParameters.ProductCopyright
         });
     }
 });
@@ -80,7 +81,8 @@ BuildParameters.Tasks.CreateNuGetPackagesTask = Task("Create-NuGet-Packages")
                 BasePath = BuildParameters.Paths.Directories.PublishedLibraries.Combine(nuspecFile.GetFilenameWithoutExtension().ToString()),
                 OutputDirectory = BuildParameters.Paths.Directories.NuGetPackages,
                 Symbols = false,
-                NoPackageAnalysis = true
+                NoPackageAnalysis = true,
+                Copyright = BuildParameters.ProductCopyright
             });
 
             continue;
@@ -94,7 +96,8 @@ BuildParameters.Tasks.CreateNuGetPackagesTask = Task("Create-NuGet-Packages")
                 BasePath = BuildParameters.Paths.Directories.PublishedApplications.Combine(nuspecFile.GetFilenameWithoutExtension().ToString()),
                 OutputDirectory = BuildParameters.Paths.Directories.NuGetPackages,
                 Symbols = false,
-                NoPackageAnalysis = true
+                NoPackageAnalysis = true,
+                Copyright = BuildParameters.ProductCopyright
             });
 
             continue;
@@ -105,7 +108,8 @@ BuildParameters.Tasks.CreateNuGetPackagesTask = Task("Create-NuGet-Packages")
             Version = BuildParameters.Version.PackageVersion,
             OutputDirectory = BuildParameters.Paths.Directories.NuGetPackages,
             Symbols = false,
-            NoPackageAnalysis = true
+            NoPackageAnalysis = true,
+            Copyright = BuildParameters.ProductCopyright
         });
     }
 });
@@ -132,7 +136,8 @@ BuildParameters.Tasks.DotNetPackTask = Task("DotNetPack")
                             .WithProperty("Version", BuildParameters.Version.PackageVersion)
                             .WithProperty("AssemblyVersion", BuildParameters.Version.FileVersion)
                             .WithProperty("FileVersion",  BuildParameters.Version.FileVersion)
-                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion);
+                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
+                            .WithProperty("Copyright", BuildParameters.ProductCopyright);
 
     if (BuildParameters.ShouldBuildNuGetSourcePackage)
     {

--- a/Chocolatey.Cake.Recipe/Content/testing.cake
+++ b/Chocolatey.Cake.Recipe/Content/testing.cake
@@ -184,7 +184,8 @@ BuildParameters.Tasks.DotNetTestTask = Task("DotNetTest")
                                 .WithProperty("Version", BuildParameters.Version.SemVersion)
                                 .WithProperty("AssemblyVersion", BuildParameters.Version.FileVersion)
                                 .WithProperty("FileVersion",  BuildParameters.Version.FileVersion)
-                                .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion);
+                                .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
+                                .WithProperty("Copyright", BuildParameters.ProductCopyright);
 
         if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
         {


### PR DESCRIPTION
## Description Of Changes

This updates the creation of Chocolatey and NuGet packages, as well as
other places that could potentially create packages (like during build
or publishing).

This is done by explicitly passing in the ProductCopyright parameter to
the locations responsible for creating packages.


## Motivation and Context

To prevent us from having to remember to update the copyright every year, as this is often forgotten.

## Testing

1. Build the Recipe project.
2. Clone down `chocolatey/choco` repository, and build it.
3. Copy the files `build.cake`, `packages.cake` and `testing.cake` to the `chocolatey/choco` repository. This should end up in a location similar to `tools/Chocolatey.Cake.Recipe.0.28.4/Content`.
4. Build the `chocolatey/choco` project using the modified cake scripts.
5. Open up the built `nupkg` files in the code_drop directory, and verify each have the same copyright as specified in the `recipe.cake` script.
6. Repeat 2-5 using the `chocolatey-community/chocolatey-community-validation` project.

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #173

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
