### PR TITLE
 (#164) Use version number in URLs 

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/notifcations.cake
+++ b/Chocolatey.Cake.Recipe/Content/notifcations.cake
@@ -137,7 +137,7 @@ BuildParameters.Tasks.SendNotificationsTask = Task("Send-Notifications")
     }
     else
     {
-        Information("Skipping sending notiifation to Discord, since input template file does not exist.");
+        Information("Skipping sending notification to Discord, since input template file does not exist.");
     }
 
     if (FileExists("./.notifications/mastodon.txt"))
@@ -157,7 +157,7 @@ BuildParameters.Tasks.SendNotificationsTask = Task("Send-Notifications")
     }
     else
     {
-        Information("Skipping sending notiifation to Mastodon, since input template file does not exist.");
+        Information("Skipping sending notification to Mastodon, since input template file does not exist.");
     }
 
     if (FileExists("./.notifications/slack.txt"))
@@ -177,7 +177,7 @@ BuildParameters.Tasks.SendNotificationsTask = Task("Send-Notifications")
     }
     else
     {
-        Information("Skipping sending notiifation to Slack, since input template file does not exist.");
+        Information("Skipping sending notification to Slack, since input template file does not exist.");
     }
 
     if (FileExists("./.notifications/twitter.txt"))
@@ -197,6 +197,6 @@ BuildParameters.Tasks.SendNotificationsTask = Task("Send-Notifications")
     }
     else
     {
-        Information("Skipping sending notiifation to Twitter, since input template file does not exist.");
+        Information("Skipping sending notification to Twitter, since input template file does not exist.");
     }
 });

--- a/Chocolatey.Cake.Recipe/Content/notifcations.cake
+++ b/Chocolatey.Cake.Recipe/Content/notifcations.cake
@@ -120,14 +120,20 @@ public void SendMessageToTwitter(string message)
 BuildParameters.Tasks.SendNotificationsTask = Task("Send-Notifications")
     .Does(() => 
 {
+    bool dryRun = Context.Argument("dry-run", false);
+
     if (FileExists("./.notifications/discord.txt"))
     {
-        if (BuildParameters.CanPostToDiscord && BuildParameters.ShouldPostToDiscord)
+        var formattedMessage = System.IO.File.ReadAllText("./.notifications/discord.txt");
+        var messageArguments = BuildParameters.DiscordMessageArguments(BuildParameters.Version);
+
+        if (dryRun)
         {
-            var formattedMessage = System.IO.File.ReadAllText("./.notifications/discord.txt");
-            var messageArguments = BuildParameters.DiscordMessageArguments(BuildParameters.Version);
-            
-            //Information(formattedMessage, messageArguments);
+            Warning("Would have sent the following to Discord:");
+            Information(formattedMessage, messageArguments);
+        }
+        else if (BuildParameters.CanPostToDiscord && BuildParameters.ShouldPostToDiscord)
+        {
             SendMessageToDiscord(string.Format(formattedMessage, messageArguments));
         }
         else
@@ -142,12 +148,16 @@ BuildParameters.Tasks.SendNotificationsTask = Task("Send-Notifications")
 
     if (FileExists("./.notifications/mastodon.txt"))
     {
-        if (BuildParameters.CanPostToMastodon && BuildParameters.ShouldPostToMastodon)
-        {
-            var formattedMessage = System.IO.File.ReadAllText("./.notifications/mastodon.txt");
-            var messageArguments = BuildParameters.MastodonMessageArguments(BuildParameters.Version);
+        var formattedMessage = System.IO.File.ReadAllText("./.notifications/mastodon.txt");
+        var messageArguments = BuildParameters.MastodonMessageArguments(BuildParameters.Version);
 
-            //Information(formattedMessage, messageArguments);
+        if (dryRun)
+        {
+            Warning("Would have sent the following to Mastodon:");
+            Information(formattedMessage, messageArguments);
+        }
+        else if (BuildParameters.CanPostToMastodon && BuildParameters.ShouldPostToMastodon)
+        {
             SendMessageToMastodon(string.Format(formattedMessage, messageArguments));
         }
         else
@@ -162,12 +172,16 @@ BuildParameters.Tasks.SendNotificationsTask = Task("Send-Notifications")
 
     if (FileExists("./.notifications/slack.txt"))
     {
-        if (BuildParameters.CanPostToSlack && BuildParameters.ShouldPostToSlack)
-        {
-            var formattedMessage = System.IO.File.ReadAllText("./.notifications/slack.txt");
-            var messageArguments = BuildParameters.SlackMessageArguments(BuildParameters.Version);
+        var formattedMessage = System.IO.File.ReadAllText("./.notifications/slack.txt");
+        var messageArguments = BuildParameters.SlackMessageArguments(BuildParameters.Version);
 
-            //Information(formattedMessage, messageArguments);
+        if (dryRun)
+        {
+            Warning("Would have sent the following to Slack:");
+            Information(formattedMessage, messageArguments);
+        }
+        else if (BuildParameters.CanPostToSlack && BuildParameters.ShouldPostToSlack)
+        {
             SendMessageToSlackChannel(string.Format(formattedMessage, messageArguments));
         }
         else
@@ -182,12 +196,16 @@ BuildParameters.Tasks.SendNotificationsTask = Task("Send-Notifications")
 
     if (FileExists("./.notifications/twitter.txt"))
     {
-        if (BuildParameters.CanPostToTwitter && BuildParameters.ShouldPostToTwitter)
-        {
-            var formattedMessage = System.IO.File.ReadAllText("./.notifications/twitter.txt");
-            var messageArguments = BuildParameters.TwitterMessageArguments(BuildParameters.Version);
+        var formattedMessage = System.IO.File.ReadAllText("./.notifications/twitter.txt");
+        var messageArguments = BuildParameters.TwitterMessageArguments(BuildParameters.Version);
 
-            //Information(formattedMessage, messageArguments);
+        if (dryRun)
+        {
+            Warning("Would have sent the following to Twitter:");
+            Information(formattedMessage, messageArguments);
+        }
+        else if (BuildParameters.CanPostToTwitter && BuildParameters.ShouldPostToTwitter)
+        {
             SendMessageToTwitter(string.Format(formattedMessage, messageArguments));
         }
         else

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -27,17 +27,7 @@ public static class BuildParameters
 {
     private static Func<BuildVersion, object[]> _defaultNotificationArguments = (x) =>
     {
-        var firstPortionOfQueryString = string.Empty;
-
-        if (x.PackageVersion.Contains("-"))
-        {
-            var betaVersionNumber = x.PackageVersion.Substring(x.PackageVersion.IndexOf('-') + 1);
-            firstPortionOfQueryString = betaVersionNumber + "-";
-        }
-
-        var dateForQueryString = DateTime.Now.ToString("MMMMM-d-yyyy").ToLower();
-
-        var arguments = new object[] { x.PackageVersion, string.Format("{0}{1}", firstPortionOfQueryString, dateForQueryString) };
+        var arguments = new object[] { x.PackageVersion, string.Format("v{0}", x.PackageVersion) };
         return arguments;
     };
 


### PR DESCRIPTION
## Description Of Changes

The commit removes the calculation of the date for the release, and
instead simply uses the version number, prefixed with a "v".

## Motivation and Context

Previously, the generated URL for release notes used the following
format:

https://docs.chocolatey.org/en-us/choco/release-notes/#july-26-2023

Where the date for the release was included.  Going forward, the
release notes are going to use the version number, similar to the
following:

https://docs.chocolatey.org/en-us/choco/release-notes/#v2.4.2

## Testing

Run the following command:

```
.\build.bat --target=Send-Notifications --dry-run=true
```

To see the output for what notifications "should" be sent.

Run the following command:

```
.\build.bat --target=Send-Notifications
```

To fall into the old code path, which will not work, since the necessary credentials have not been configured.

### Operating Systems Testing

N/A

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #164 