### PR TITLE
(#157) Fix PowerShell signing up to date throws exception

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/sign.cake
+++ b/Chocolatey.Cake.Recipe/Content/sign.cake
@@ -36,6 +36,12 @@ BuildParameters.Tasks.VerifyPowerShellScriptsTask = Task("Verify-PowerShellScrip
             scriptsToVerify.Add(MakeAbsolute(filePath).FullPath);
         }
 
+        if (scriptsToVerify.Count == 0)
+        {
+            Information("There are no PowerShell Scripts defined to be verified.");
+            return;
+        }
+
         StartPowershellFile(MakeAbsolute(powerShellVerifyScript), args =>
         {
             args.AppendArray("ScriptsToVerify", scriptsToVerify);
@@ -69,6 +75,12 @@ BuildParameters.Tasks.SignPowerShellScriptsTask = Task("Sign-PowerShellScripts")
             scriptsToSign.Add(MakeAbsolute(filePath).FullPath);
         }
 
+        if (scriptsToSign.Count == 0)
+        {
+            Warning("Unable to find PowerShell signing script, so unable to sign PowerShell scripts.");
+            return;
+        }
+
         if (BuildSystem.IsRunningOnTeamCity)
         {
             StartPowershellFile(MakeAbsolute(powerShellSigningScript), args =>
@@ -99,6 +111,14 @@ BuildParameters.Tasks.SignPowerShellScriptsTask = Task("Sign-PowerShellScripts")
 
         var files = GetFiles(BuildParameters.Paths.Directories.SignedFiles + "/**/*") - GetFiles(BuildParameters.Paths.Directories.SignedFiles + "/**/*.zip");
         var destination = BuildParameters.Paths.Directories.SignedFiles.CombineWithFilePath("SignedFiles.zip");
+
+        if (files.Count == 0 || !FileExists(destination))
+        {
+            Information("No PowerShell scripts found, or all PowerShell scripts have already been signed.");
+            return;
+        }
+
+
         Zip(BuildParameters.Paths.Directories.SignedFiles, destination, files);
 
         BuildParameters.BuildProvider.UploadArtifact(destination);


### PR DESCRIPTION
## Description Of Changes

This fixes an issue that happens when PowerShell scripts have all been
signed, and there is no need to update the signature for these scripts.

## Motivation and Context

Without this change, our internal builds to sign the scripts throws an
exception due to no files being found.

## Testing

1. Copy the file `sign.cake` to a repository of your choosing.
2. Run the build script, and ensure there are no compile errors.

While I would like to test the actual functionality, I have not figured out a way to test the behavior properly.

### Operating Systems Testing

- Windows 10

## Change Types Made
<!-- Tick the boxes for the type of changes that have been made -->

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue
<!-- Make sure you have raised an issue for this pull request before
continuing. -->

Fixes #157

<!-- PLEASE REMOVE ALL COMMENTS BEFORE SUBMITTING -->
