### PR TITLE
(#181) Allow ILMerge task to work on it's own

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/ilmerge.cake
+++ b/Chocolatey.Cake.Recipe/Content/ilmerge.cake
@@ -14,6 +14,8 @@
 // limitations under the License.
 
 BuildParameters.Tasks.ILMergeTask = Task("Run-ILMerge")
+    .IsDependentOn("Build")
+    .IsDependentOn("Test")
     .IsDependeeOf("Copy-Nuspec-Folders")
     .WithCriteria(() => BuildParameters.ShouldRunILMerge, "Skipping because ILMerge is not enabled")
     .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping because not running on Windows")


### PR DESCRIPTION
## Description Of Changes

Update ILMerge task to function as an independent task without requiring running Build beforehand.

## Motivation and Context

Be able to ILMerge projects without specifying to build them first.

## Testing

Copied the `ilmerge.cake` file into `chocolatey/choco` repository and ran `.\build.bat --target=Run-ILMerge`

### Operating Systems Testing

Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #181