### PR TITLE
(#185) Fix ILMerge DAG

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -594,6 +594,8 @@ public class Builder
         BuildParameters.Tasks.InspectCodeTask.IsDependentOn(prefix + "Build");
         BuildParameters.Tasks.ConfigurationBuilderTask.IsDependentOn(prefix + "Build");
         BuildParameters.Tasks.TestTask.IsDependentOn(prefix + "Build");
+        BuildParameters.Tasks.ILMergeTask.IsDependentOn(prefix + "Build");
+        BuildParameters.Tasks.ILMergeTask.IsDependentOn(prefix + "Test");
 
         BuildParameters.Tasks.InitializeSonarQubeTask.IsDependeeOf(prefix + "Build");
         BuildParameters.Tasks.FinaliseSonarQubeTask.IsDependentOn(prefix + "Build");

--- a/Chocolatey.Cake.Recipe/Content/ilmerge.cake
+++ b/Chocolatey.Cake.Recipe/Content/ilmerge.cake
@@ -14,8 +14,6 @@
 // limitations under the License.
 
 BuildParameters.Tasks.ILMergeTask = Task("Run-ILMerge")
-    .IsDependentOn("Build")
-    .IsDependentOn("Test")
     .IsDependeeOf("Copy-Nuspec-Folders")
     .WithCriteria(() => BuildParameters.ShouldRunILMerge, "Skipping because ILMerge is not enabled")
     .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping because not running on Windows")


### PR DESCRIPTION
## Description Of Changes

Adjust the ILMerge DAG to pick up the correct build and test tasks for the project.

## Motivation and Context

See #185 

## Testing

In the CLI and CCM repositories:

1. Run `./build.ps1 --target=Clean`
2. Copy the changes from this PR into `tools/Chocolatey.Cake.Recipe.<version>/Content`
4. Run `./build.ps1 --shouldObfuscateOutputAssemblies=false` in the CCM repository, and `./build.ps1 --target=Run-ILMerge` in the CLI repository.
5. Ensure build completes successfully.

### Operating Systems Testing

Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #185 
