### PR TITLE
(#186) Treat Warning as Error for DotNet builds

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -186,6 +186,7 @@ BuildParameters.Tasks.DotNetBuildTask = Task("DotNetBuild")
 
         var msBuildSettings = new DotNetCoreMSBuildSettings()
                             .WithProperty("Version", BuildParameters.Version.SemVersion)
+                            .WithProperty("TreatWarningsAsErrors", BuildParameters.TreatWarningsAsErrors.ToString())
                             .WithProperty("AssemblyVersion", BuildParameters.Version.FileVersion)
                             .WithProperty("FileVersion",  BuildParameters.Version.FileVersion)
                             .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)


### PR DESCRIPTION
## Description Of Changes

Pass TreatWarningsAsErrors to DotNet builds.

## Motivation and Context

See #186 

## Testing

In the CCM repository:

1. Run `./build.ps1 --target=Clean`
2. Copy the changes from this PR into `tools/Chocolatey.Cake.Recipe.<version>/Content`
4. Run `./build.ps1`.
5. Ensure build errors (there are warnings that should cause an error).
6. Adjust the CCM recipe to pass `treatWarningsAsErrors` to the build as `false`
7. Run `./build.ps1`.
8. Ensure the build completes successfully.

### Operating Systems Testing

Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #186
