### PR TITLE
(#188) Don't reset Eazfuscator settings

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/eazfuscator.cake
+++ b/Chocolatey.Cake.Recipe/Content/eazfuscator.cake
@@ -51,15 +51,17 @@ BuildParameters.Tasks.ObfuscateAssembliesTask = Task("Obfuscate-Assemblies")
 
             foreach (var file in BuildParameters.GetFilesToObfuscate())
             {
-                // This needs to be "reset" so that previously set properties aren't in place for the next iteration.
-                settings = new EazfuscatorNetSettings();
-
                 var fileName = file.GetFilenameWithoutExtension();
                 var msbuildPathFilePath = new FilePath(string.Format("{0}/{1}/{1}.csproj", BuildParameters.SourceDirectoryPath.FullPath, fileName));
 
+                // We want to ensure we don't reuse settings between runs. Reset the MSBuildProjectPath to null if this file doesn't need it.
                 if (FileExists(msbuildPathFilePath))
                 {
                     settings.MSBuildProjectPath = msbuildPathFilePath;
+                }
+                else
+                {
+                    settings.MSBuildProjectPath = null;
                 }
 
                 try {


### PR DESCRIPTION
## Description Of Changes

Don't reset the Eazfuscator settings for DotNet builds.

## Motivation and Context

See #188

## Testing

In the CCM repositories:

1. Run `./build.ps1 --target=Clean`
2. Copy the changes from this PR into `tools/Chocolatey.Cake.Recipe.<version>/Content`
4. Run `./build.ps1 --verbosity=diagnostic` in the CCM repository.
5. Ensure build completes successfully.
6. Ensure the Obfuscation step includes statistics for obfuscation. You should see log output like: `Executing: "C:/code/choco-licensed-management-ui/lib/Eazfuscator.NET/Eazfuscator.NET.exe" "C:/code/choco-licensed-management-ui/code_drop/temp/_PublishedLibs/chocolatey.console.service/net8.0/chocolatey.console.service.dll" --msbuild-project-path "C:/code/choco-licensed-management-ui/src/chocolatey.console.service/chocolatey.console.service.csproj" --statistics` (note the `--statistics` on the end.

### Operating Systems Testing

Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #188 
