### PR TITLE
(#193) Collect Obfuscation Failures

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/eazfuscator.cake
+++ b/Chocolatey.Cake.Recipe/Content/eazfuscator.cake
@@ -17,6 +17,7 @@ BuildParameters.Tasks.ObfuscateAssembliesTask = Task("Obfuscate-Assemblies")
     .WithCriteria(() => BuildParameters.ShouldObfuscateOutputAssemblies, "Skipping since obfuscating output assemblies has been disabled")
     .Does(() =>
 {
+    List<string> exceptions = new List<string>();
     if (BuildParameters.GetFilesToObfuscate != null)
     {
         var settings = new EazfuscatorNetSettings();
@@ -61,7 +62,11 @@ BuildParameters.Tasks.ObfuscateAssembliesTask = Task("Obfuscate-Assemblies")
                     settings.MSBuildProjectPath = msbuildPathFilePath;
                 }
 
-                EazfuscatorNet(file, settings);
+                try {
+                    EazfuscatorNet(file, settings);
+                } catch {
+                    exceptions.Add(fileName.ToString());
+                }
             }
         }
         else
@@ -78,5 +83,10 @@ BuildParameters.Tasks.ObfuscateAssembliesTask = Task("Obfuscate-Assemblies")
     else
     {
         Information("There are no files defined to be obfuscated.");
+    }
+
+    if (exceptions.Count != 0) {
+        Error("Failed to obfuscate projects: {0}", exceptions.Join(", "));
+        throw new ApplicationException("Obfuscation failed");
     }
 });


### PR DESCRIPTION
## Description Of Changes

Collect obfuscation failures and report on them at the end instead of failing early.

## Motivation and Context

See #193 

## Testing

This testing is predicated on the `develop` ranch of CCM being where it is at this point in time. If the PR that fixes the obfuscation on Dev VM 3 is merged, you will need to adjust testing accordingly.

On the CCM `develop` branch on Dev VM 3:

1. Run `./build.ps1 --target=clean`
2. Copy the contents of this commit into `tools/Chocolatey.Cake.Recipe.<version>/Content`
3. Run `./build.ps1 --target=obfuscate-assemblies`
4. Ensure that the build fails and at the end reports which projects failed to build (it will not be all of them).

### Operating Systems Testing

Windows 11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #193
