### PR TITLE
(#199) Use Cake.Git's methods to identifying if we're in a git repository.

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/gitversion.cake
+++ b/Chocolatey.Cake.Recipe/Content/gitversion.cake
@@ -52,7 +52,7 @@ public class BuildVersion
             };
         }
 
-        context.Information("Testing to see if valid git repository...");
+        context.Information("Testing to see if valid git repository for GitVersion use...");
 
         var rootPath = BuildParameters.RootDirectoryPath;
         

--- a/Chocolatey.Cake.Recipe/Content/gitversion.cake
+++ b/Chocolatey.Cake.Recipe/Content/gitversion.cake
@@ -52,14 +52,15 @@ public class BuildVersion
             };
         }
 
-        try
-        {
-            context.Information("Testing to see if valid git repository...");
+        context.Information("Testing to see if valid git repository...");
 
-            var rootPath = BuildParameters.RootDirectoryPath;
+        var rootPath = BuildParameters.RootDirectoryPath;
+        
+        if (context.GitIsValidRepository(rootPath))
+        {
             rootPath = context.GitFindRootFromPath(rootPath);
         }
-        catch (LibGit2Sharp.RepositoryNotFoundException)
+        else
         {
             context.Warning("Unable to locate git repository, so GitVersion can't be executed, returning default version numbers...");
 

--- a/Chocolatey.Cake.Recipe/Content/localbuild.cake
+++ b/Chocolatey.Cake.Recipe/Content/localbuild.cake
@@ -68,7 +68,7 @@ public class LocalBuildRepositoryInfo : IRepositoryInfo
 {
     public LocalBuildRepositoryInfo(ICakeContext context)
     {
-        context.Information("Testing to see if valid git repository...");
+        context.Information("Testing to see if valid git repository for LocalBuild setup...");
 
         if (context.GitIsValidRepository(context.MakeAbsolute(context.Environment.WorkingDirectory)))
         {

--- a/Chocolatey.Cake.Recipe/Content/localbuild.cake
+++ b/Chocolatey.Cake.Recipe/Content/localbuild.cake
@@ -68,9 +68,10 @@ public class LocalBuildRepositoryInfo : IRepositoryInfo
 {
     public LocalBuildRepositoryInfo(ICakeContext context)
     {
-        try
+        context.Information("Testing to see if valid git repository...");
+
+        if (context.GitIsValidRepository(context.MakeAbsolute(context.Environment.WorkingDirectory)))
         {
-            context.Information("Testing to see if valid git repository...");
 
             // Normally, would use BuildParameters.RootDirectoryPath here, but since
             // BuildProvider is executed before the Setup Task has executed, this property
@@ -143,7 +144,7 @@ public class LocalBuildRepositoryInfo : IRepositoryInfo
                 Tag = new LocalBuildTagInfo(context);
             }
         }
-        catch (LibGit2Sharp.RepositoryNotFoundException)
+        else
         {
             context.Warning("Unable to locate git repository, setting default values for repository properties...");
 


### PR DESCRIPTION
## Description Of Changes

Use the methods provided by Cake.Git to identify if we're in a git repository.

## Motivation and Context

The way we were testing for a git repository before just caused a hang if it wasn't a git repository.

## Testing

1. Copy the contents into the correct place in a chocolatey/choco clone that has had the `.git` directory removed.
2. Run ./build.bat and ensure it completes successfully.

### Operating Systems Testing

Windows Server 2019.

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #199