### PR TITLE
(#211) Ensure SolutionVersion.cs file is created

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/gitversion.cake
+++ b/Chocolatey.Cake.Recipe/Content/gitversion.cake
@@ -55,7 +55,7 @@ public class BuildVersion
         context.Information("Testing to see if valid git repository for GitVersion use...");
 
         var rootPath = BuildParameters.RootDirectoryPath;
-        
+
         if (context.GitIsValidRepository(rootPath))
         {
             rootPath = context.GitFindRootFromPath(rootPath);

--- a/Chocolatey.Cake.Recipe/Content/gitversion.cake
+++ b/Chocolatey.Cake.Recipe/Content/gitversion.cake
@@ -39,15 +39,20 @@ public class BuildVersion
         {
             context.Information("Running GitVersion is not enabled, so returning default values...");
 
+            var fakeFileVersion = "0.1.0.0";
+            var fakeInformationalVersion = "0.1.0-alpha.0+Branch.develop.Sha.528f9bf572a52f0660cbe3f4d109599eab1e9866";
+
+            GenerateSolutionVersionFile(context, fakeFileVersion, fakeInformationalVersion);
+
             return new BuildVersion
             {
                 MajorMinorPatch = "0.1.0",
                 SemVersion = "0.1.0-alpha.0",
                 Milestone = "0.1.0",
                 CakeVersion = cakeVersion,
-                FileVersion = "0.1.0.0",
+                FileVersion = fakeFileVersion,
                 PackageVersion = "0.1.0-alpha-20220317-13",
-                InformationalVersion = "0.1.0-alpha.0+Branch.develop.Sha.528f9bf572a52f0660cbe3f4d109599eab1e9866",
+                InformationalVersion = fakeInformationalVersion,
                 FullSemVersion = "0.1.0-alpha.0",
             };
         }
@@ -177,6 +182,38 @@ public class BuildVersion
             context.Information("There is a tag.");
         }
 
+        GenerateSolutionVersionFile(context, fileVersion, informationalVersion);
+
+        context.Information("Calculated Major.Minor.Patch: {0}", majorMinorPatch);
+        context.Information("Calculated Sem Version: {0}", semVersion);
+        context.Information("Calculated Milestone: {0}", milestone);
+        context.Information("Cake Version: {0}", cakeVersion);
+        context.Information("Calculated File Version: {0}", fileVersion);
+        context.Information("Calculated Package Version: {0}", packageVersion);
+        context.Information("Calculated Informational Version: {0}", informationalVersion);
+        context.Information("Calculate Full Sem Version: {0}", fullSemVersion);
+
+        if (context.BuildSystem().IsRunningOnTeamCity)
+        {
+            // use the asserted package version for the build number in TeamCity
+            context.BuildSystem().TeamCity.SetBuildNumber(packageVersion);
+        }
+
+        return new BuildVersion
+        {
+            MajorMinorPatch = majorMinorPatch,
+            SemVersion = semVersion,
+            Milestone = milestone,
+            CakeVersion = cakeVersion,
+            FileVersion = fileVersion,
+            PackageVersion = packageVersion,
+            InformationalVersion = informationalVersion,
+            FullSemVersion = fullSemVersion,
+        };
+    }
+
+    private static void GenerateSolutionVersionFile(ICakeContext context, string fileVersion, string informationalVersion)
+    {
         if (BuildParameters.ShouldGenerateSolutionVersionCSharpFile)
         {
             context.Information("Generating SolutionVersion.cs file...");
@@ -230,33 +267,6 @@ public class BuildVersion
         {
             context.Information("Skipping generation of SolutionVersion.cs file.");
         }
-
-        context.Information("Calculated Major.Minor.Patch: {0}", majorMinorPatch);
-        context.Information("Calculated Sem Version: {0}", semVersion);
-        context.Information("Calculated Milestone: {0}", milestone);
-        context.Information("Cake Version: {0}", cakeVersion);
-        context.Information("Calculated File Version: {0}", fileVersion);
-        context.Information("Calculated Package Version: {0}", packageVersion);
-        context.Information("Calculated Informational Version: {0}", informationalVersion);
-        context.Information("Calculate Full Sem Version: {0}", fullSemVersion);
-
-        if (context.BuildSystem().IsRunningOnTeamCity)
-        {
-            // use the asserted package version for the build number in TeamCity
-            context.BuildSystem().TeamCity.SetBuildNumber(packageVersion);
-        }
-
-        return new BuildVersion
-        {
-            MajorMinorPatch = majorMinorPatch,
-            SemVersion = semVersion,
-            Milestone = milestone,
-            CakeVersion = cakeVersion,
-            FileVersion = fileVersion,
-            PackageVersion = packageVersion,
-            InformationalVersion = informationalVersion,
-            FullSemVersion = fullSemVersion,
-        };
     }
 
     private static void PatchGitLibConfigFiles(ICakeContext context)


### PR DESCRIPTION
## Description Of Changes

This commit addresses this issue by creating a new method named
GenerateSolutionVersionFile, which is called now from two places.  The
first, where the code was previously, and the second is the if
statements which gates the running of GitVersion.  Now, the "fake"
asserted version numbers are passed into this new method, which then
ensures that the SolutionVersion.cs is created, and the build continues.

## Motivation and Context

There is a code path which can be executed where GitVersion is not
executed, i.e. when using:

./build.bat --ShouldRunGitVersion=false

When doing this, the code generates a "fake" set of version numbers,
however, those version numbers never made their way into a generated
SolutionVersion.cs file (which is "needed" to have a successful build.

## Testing

Use the instructions on the internal wiki to run with the latest version of the Chocolatey.Cake.Recipe package, but replace the usage of the gitversion.cake file with the one from this PR.

1. Run `./build.bat --ShouldRunGitVersion=false`
2. Note that the build succeeds, where it would have failed before.

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #211