### PR TITLE
Add check for IsOriginalRepository

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/buildProvider.cake
+++ b/Chocolatey.Cake.Recipe/Content/buildProvider.cake
@@ -56,6 +56,8 @@ public interface IPullRequestInfo
 public interface IBuildInfo
 {
     string Number { get; }
+
+    Dictionary<string, string> BuildProperties { get; }
 }
 
 public interface IBuildProvider

--- a/Chocolatey.Cake.Recipe/Content/github-actions.cake
+++ b/Chocolatey.Cake.Recipe/Content/github-actions.cake
@@ -128,9 +128,11 @@ public class GitHubActionBuildInfo : IBuildInfo
     public GitHubActionBuildInfo(ICakeContext context)
     {
         Number = context.BuildSystem().GitHubActions.Environment.Workflow.RunNumber.ToString();
+        BuildProperties = new Dictionary<string, string>();
     }
 
     public string Number { get; }
+    public Dictionary<string, string> BuildProperties { get; }
 }
 
 public class GitHubActionBuildProvider : IBuildProvider

--- a/Chocolatey.Cake.Recipe/Content/localbuild.cake
+++ b/Chocolatey.Cake.Recipe/Content/localbuild.cake
@@ -176,9 +176,11 @@ public class LocalBuildBuildInfo : IBuildInfo
     public LocalBuildBuildInfo()
     {
         Number = "-1";
+        BuildProperties = new Dictionary<string, string>();
     }
 
     public string Number { get; }
+    public Dictionary<string, string> BuildProperties { get; }
 }
 
 public class LocalBuildBuildProvider : IBuildProvider

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -108,6 +108,7 @@ public static class BuildParameters
     public static bool IsLocalBuild { get; private set; }
     public static bool IsPullRequest { get; private set; }
     public static bool IsTagged { get; private set; }
+    public static bool IsOriginalRepository { get; private set; }
     public static string MasterBranchName { get; private set; }
     public static MastodonCredentials Mastodon { get; private set; }
     public static Func<BuildVersion, object[]> MastodonMessageArguments { get; private set; }
@@ -242,6 +243,7 @@ public static class BuildParameters
         context.Information("IsLocalBuild: {0}", IsLocalBuild);
         context.Information("IsPullRequest: {0}", IsPullRequest);
         context.Information("IsTagged: {0}", IsTagged);
+        context.Information("IsOriginalRepository: {0}", IsOriginalRepository);
         context.Information("NuGetNupkgGlobbingPattern: {0}", NuGetNupkgGlobbingPattern);
         context.Information("NuGetNuspecGlobbingPattern: {0}", NuGetNuspecGlobbingPattern);
         context.Information("NuGetSources: {0}", string.Join(", ", NuGetSources));
@@ -497,6 +499,16 @@ public static class BuildParameters
         IsLocalBuild = buildSystem.IsLocalBuild;
         IsPullRequest = BuildProvider.PullRequest.IsPullRequest;
         IsTagged = BuildProvider.Repository.Tag.IsTag;
+        // Some information in TeamCity isn't directly accessible, so we need to go hunting for it! The BuildProperties is
+        // a dictionary of all of the properties contained within a file on disk on the build agent.
+        var buildProperties = BuildProvider.Build.BuildProperties;
+        var vcsRootUrl = string.Empty;
+        if(buildProperties.ContainsKey("vcsroot.url"))
+        {
+            vcsRootUrl = buildProperties["vcsrooot.url"];
+        }
+        // This is a check to see whether the URL matches with something like "chocolatey/choco.git"
+        IsOriginalRepository = vcsRootUrl.EndsWith(string.Concat(RepositoryOwner, "/", RepositoryName, ".git"), StringComparison.OrdinalIgnoreCase);
         MasterBranchName = masterBranchName;
         Mastodon = GetMastodonCredentials(context);
         MastodonMessageArguments = mastodonMessageArguments ?? _defaultNotificationArguments;

--- a/Chocolatey.Cake.Recipe/Content/teamcity.cake
+++ b/Chocolatey.Cake.Recipe/Content/teamcity.cake
@@ -146,9 +146,11 @@ public class TeamCityBuildInfo : IBuildInfo
     public TeamCityBuildInfo(ITeamCityProvider teamCity)
     {
         Number = teamCity.Environment.Build.Number;
+        BuildProperties = teamCity.Environment.Build.BuildProperties;
     }
 
     public string Number { get; }
+    public Dictionary<string, string> BuildProperties { get; }
 }
 
 public class TeamCityBuildProvider : IBuildProvider


### PR DESCRIPTION
> [!WARNING]
> This will not work until we use at least version 1.1.0 of Cake :-(

## Description Of Changes

This commit adds a new property called `IsOriginalRepository`, which tries to ensure that the original
repository, and not a fork of the repository is being used.  In TeamCity, we have to go and "find" this information
and we may need to surface it in a slightly different way, so that it can be agnostic across build providers, but
for now, this  has come to a bit of a halt, since the `BuildProperties` property doesn't exist in the version of Cake
that we are currently using.

## Motivation and Context

We need a way to prevent certain parts of the build from executing, when it is being run on a fork
of the original repository.  We can get this information from TeamCity via the BuildProperties collection
but we may need to find other locations of this information from the other build providers.

## Testing

None, yet.

### Operating Systems Testing

- Windows 11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

Fixes #23