### PR TITLE
(#282) Allow building with the latest SSMS installed.

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/toolsettings.cake
+++ b/Chocolatey.Cake.Recipe/Content/toolsettings.cake
@@ -211,6 +211,8 @@ public static class ToolSettings
         var vsWhereProductSettings = new VSWhereProductSettings
         {
             Version = versionRange,
+            ReturnProperty = null,
+            ArgumentCustomization = args => args.Append("-find MSBuild/**/bin/MSBuild.exe")
         };
 
         if (!string.IsNullOrEmpty(versionRange))
@@ -231,7 +233,9 @@ public static class ToolSettings
 
         var vsWhereLegacySettings = new VSWhereLegacySettings
         {
-            Version = versionRange
+            Version = versionRange,
+            ReturnProperty = null,
+            ArgumentCustomization = args => args.Append("-find MSBuild/**/bin/MSBuild.exe")
         };
 
         if (!string.IsNullOrEmpty(versionRange))

--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ And if you need to use a specific version of the package, you can use something 
 
 ### Local Development
 
-The easiest way to do local development of this package is to load the latest released version from NuGet, and exclude the cake files you're iterating.
+The easiest way to do local development of this package is to load the latest released version from NuGet, and include only the `version.cake` file. Then load all of the local cake files. The `version.cake` file is a file that is generated during the build, and contains required information.
 
-For example, to work with the `sign.cake` file, your `recipe.cake` file might include:
+For example, if this repository is checked out to `C:\code\Chocolatey.Cake.Recipe`, you could use the following to build from it:
 
 ```
-#load nuget:?package`Chocolatey.Cake.Recipe&Version=0.30.1&Exclude=/**/sign.cake
-#load local:?path=C:/code/Chocolatey.Cake.Recipe/Chocolatey.Cake.Recipe/Content/sign.cake
+#load nuget:?package`Chocolatey.Cake.Recipe&Version=0.30.1&Include=/**/version.cake
+#load local:?path=C:/code/Chocolatey.Cake.Recipe/Chocolatey.Cake.Recipe/Content/*.cake
 ```
 
 *NOTE:* This method only applies to cake files. Any other files included with the package (like PowerShell files) will need to be copied into your repository's working copy of Chocolatey.Cake.Recipe.


### PR DESCRIPTION
## Description Of Changes

Update the logic to find an MSBuild that actually has an MSBuild?

## Motivation and Context

Being able to build things while the latest SSMS is installed.

## Testing

For any project using this recipe, apply a similar diff to this:

```
diff --git a/recipe.cake b/recipe.cake
index bc029d1f..30269b28 100644
--- a/recipe.cake
+++ b/recipe.cake
@@ -1,4 +1,5 @@
-#load nuget:?package=Chocolatey.Cake.Recipe&version=0.30.1
+#load nuget:?package=Chocolatey.Cake.Recipe&version=0.30.1&Include=/**/version.cake
+#load local:?path=C:/code/chocolatey.cake.recipe/chocolatey.cake.recipe/Content/*.cake
 #tool nuget:?package=WiX&version=3.11.2
 ```

Run the build script.

### Operating Systems Testing

Windows 11

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?

## Related Issue

- Fixes #282 