### PR TITLE
(#286) Use tag as version number when present

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -38,6 +38,7 @@ Setup<BuildData>(context =>
         BuildParameters.SetBuildVersion(
             BuildVersion.CalculatingSemanticVersion(
                 context: Context,
+                buildSystem: BuildSystem,
                 preReleaseLabelFilePath: BuildParameters.PreReleaseLabelFilePath
             )
         );

--- a/Chocolatey.Cake.Recipe/Content/gitversion.cake
+++ b/Chocolatey.Cake.Recipe/Content/gitversion.cake
@@ -26,6 +26,7 @@ public class BuildVersion
 
     public static BuildVersion CalculatingSemanticVersion(
         ICakeContext context,
+        BuildSystem buildSystem,
         string preReleaseLabelFilePath)
     {
         if (context == null)
@@ -174,12 +175,35 @@ public class BuildVersion
                                 BuildParameters.BuildCounter != "-1" ? string.Format("-{0}", BuildParameters.BuildCounter) : string.Empty);
             informationalVersion = string.Format("{0}-{1}{2}-{3}", majorMinorPatch, prerelease, buildDate, sha);
             context.Information("There is no tag.");
+
+            if (buildSystem.IsRunningOnTeamCity)
+            {
+                // use the asserted package version for the build number in TeamCity
+                buildSystem.TeamCity.SetBuildNumber(packageVersion);
+            }
         }
         else
         {
-            packageVersion = semVersion;
-            informationalVersion = semVersion;
-            context.Information("There is a tag.");
+            var tag = BuildParameters.BuildProvider.Repository.Tag.Name;
+            packageVersion = tag;
+            informationalVersion = tag;
+            semVersion = tag;
+            fullSemVersion = tag;
+
+            var match = System.Text.RegularExpressions.Regex.Match(tag, @"^(\d+\.\d+\.\d+)");
+            majorMinorPatch = match.Groups[1].Value;
+
+            milestone = majorMinorPatch;
+            fileVersion = string.Format("{0}.0", milestone);
+
+            context.Information("There is a tag: '{0}'", tag);
+
+            if (buildSystem.IsRunningOnTeamCity)
+            {
+                // Since running of GitVersion may have set the TeamCity build number
+                // to an incorrect version, let's set it again, just to make sure.
+                buildSystem.TeamCity.SetBuildNumber(tag);
+            }
         }
 
         GenerateSolutionVersionFile(context, fileVersion, informationalVersion);
@@ -192,12 +216,6 @@ public class BuildVersion
         context.Information("Calculated Package Version: {0}", packageVersion);
         context.Information("Calculated Informational Version: {0}", informationalVersion);
         context.Information("Calculate Full Sem Version: {0}", fullSemVersion);
-
-        if (context.BuildSystem().IsRunningOnTeamCity)
-        {
-            // use the asserted package version for the build number in TeamCity
-            context.BuildSystem().TeamCity.SetBuildNumber(packageVersion);
-        }
 
         return new BuildVersion
         {

--- a/Chocolatey.Cake.Recipe/Content/teamcity.cake
+++ b/Chocolatey.Cake.Recipe/Content/teamcity.cake
@@ -39,10 +39,11 @@ public class TeamCityTagInfo : ITagInfo
 
         if (exitCode == 0)
         {
-            if (redirectedStandardOutput.Count() != 0)
+            var outputLines = redirectedStandardOutput.ToList();
+            if (outputLines.Count != 0)
             {
                 IsTag = true;
-                Name = redirectedStandardOutput.FirstOrDefault();
+                Name = outputLines.FirstOrDefault();
             }
         }
     }


### PR DESCRIPTION
## Description Of Changes

The decision has been made that if a tag is present, we should always use that tag as the basis of the asserted version number, regardless of what is generated from GitVersion.

To ensure that TeamCity sets the correct version number in its UI, an additional call is made once the tag has been chosen as the asserted version number.  This is done by GitVersion automatically, but it will have used the wrong version number, so we need to be explicit about setting it again.

## Motivation and Context

Historically, we could always rely on GitVersion using the tag as part of the asserted version number when a tag was present on a commit. However, we have noticed recently that GitVersion fails to use the tag when present, under certain circumstances.  It seems to be the case that when a support branch is active, as the same time a release branch is active, that the asserted version number is incorrect.

## Testing

1. Check out this PR, and copy the build files into the Chocolatey.Cake.Recipe package folder for Chocolatey CLI
2. Run `.\build.bat`
3. Ensure that build runs successfully
4. Other changes can really only be asserted once updated to run on actual project

### Operating Systems Testing

- Dev VM 4

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #286