### PR TITLE
(#287) Prevent creation of AssemblyKeyFile 

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/gitversion.cake
+++ b/Chocolatey.Cake.Recipe/Content/gitversion.cake
@@ -257,7 +257,7 @@ public class BuildVersion
             {
                 assemblyInfoSettings.CustomAttributes = new List<AssemblyInfoCustomAttribute>();
 
-                if (BuildParameters.ShouldStrongNameOutputAssemblies)
+                if (BuildParameters.ShouldStrongNameOutputAssemblies && !BuildParameters.IsDotNetBuild)
                 {
                     var assemblyKeyFileAttribute = new AssemblyInfoCustomAttribute
                     {


### PR DESCRIPTION
## Description Of Changes

While it doesn't do any "harm" to have both of them, it does cause some
confusion, and there are also warnings emitted in the build log.

With this in mind, the decision was taken to no longer include the
AssemblyKeyFile attribute when doing .NET builds.

## Motivation and Context

When running a .NET build, we no longer need the AssemblyKeyFile
attribute to be added to the generated SolutionVersion.cs file.  This
is because this information is now set in the csproj file (when using
the new csproj format).

## Testing

1. Check out this PR, and copy the build files into the Chocolatey.Cake.Recipe package folder for Chocolatey CLI
1. Run .\build.bat
1. Verify attribute is _not_ present in SolutionVersion.cs file

### Operating Systems Testing

- Dev VM 4

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #287 