### PR TITLE
(#288) Remove overriding of framework path

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -108,15 +108,6 @@ BuildParameters.Tasks.DotNetRestoreTask = Task("DotNetRestore")
                             .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
                             .WithProperty("Copyright", BuildParameters.ProductCopyright);
 
-    if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
-    {
-        var frameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/";
-
-        // Use FrameworkPathOverride when not running on Windows.
-        Information("Restore will use FrameworkPathOverride={0} since not building on Windows.", frameworkPathOverride);
-        msBuildSettings.WithProperty("FrameworkPathOverride", frameworkPathOverride);
-    }
-
     DotNetCoreRestore(BuildParameters.SolutionFilePath.FullPath, new DotNetCoreRestoreSettings
     {
         Sources = BuildParameters.NuGetSources,
@@ -198,15 +189,6 @@ BuildParameters.Tasks.DotNetBuildTask = Task("DotNetBuild")
                             .WithProperty("FileVersion",  BuildParameters.Version.FileVersion)
                             .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
                             .WithProperty("Copyright", BuildParameters.ProductCopyright);
-
-        if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
-        {
-            var frameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/";
-
-            // Use FrameworkPathOverride when not running on Windows.
-            Information("Build will use FrameworkPathOverride={0} since not building on Windows.", frameworkPathOverride);
-            msBuildSettings.WithProperty("FrameworkPathOverride", frameworkPathOverride);
-        }
 
         DotNetCoreBuild(BuildParameters.SolutionFilePath.FullPath, new DotNetCoreBuildSettings
         {
@@ -359,15 +341,6 @@ public void CopyBuildOutput()
                             .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
                             .WithProperty("Copyright", BuildParameters.ProductCopyright);
 
-                if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
-                {
-                    var frameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/";
-
-                    // Use FrameworkPathOverride when not running on Windows.
-                    Information("Publish will use FrameworkPathOverride={0} since not building on Windows.", frameworkPathOverride);
-                    msBuildSettings.WithProperty("FrameworkPathOverride", frameworkPathOverride);
-                }
-
                 foreach (var targetFramework in parsedProject.NetCore.TargetFrameworks)
                 {
                     Information("Running dotnet publish for {0}...", project.Path.FullPath);
@@ -421,15 +394,6 @@ public void CopyBuildOutput()
                             .WithProperty("FileVersion",  BuildParameters.Version.FileVersion)
                             .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
                             .WithProperty("Copyright", BuildParameters.ProductCopyright);
-
-                if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
-                {
-                    var frameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/";
-
-                    // Use FrameworkPathOverride when not running on Windows.
-                    Information("Publish will use FrameworkPathOverride={0} since not building on Windows.", frameworkPathOverride);
-                    msBuildSettings.WithProperty("FrameworkPathOverride", frameworkPathOverride);
-                }
 
                 foreach (var targetFramework in parsedProject.NetCore.TargetFrameworks)
                 {

--- a/Chocolatey.Cake.Recipe/Content/testing.cake
+++ b/Chocolatey.Cake.Recipe/Content/testing.cake
@@ -187,15 +187,6 @@ BuildParameters.Tasks.DotNetTestTask = Task("DotNetTest")
                                 .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
                                 .WithProperty("Copyright", BuildParameters.ProductCopyright);
 
-        if (BuildParameters.BuildAgentOperatingSystem != PlatformFamily.Windows)
-        {
-            var frameworkPathOverride = new FilePath(typeof(object).Assembly.Location).GetDirectory().FullPath + "/";
-
-            // Use FrameworkPathOverride when not running on Windows.
-            Information("Restore will use FrameworkPathOverride={0} since not building on Windows.", frameworkPathOverride);
-            msBuildSettings.WithProperty("FrameworkPathOverride", frameworkPathOverride);
-        }
-
         var projectsToTest = new FilePathCollection();
 
         if (BuildParameters.TestExecutionType == "unit")


### PR DESCRIPTION
## Description Of Changes

It is believed that this framework override was needed at some point in
the past, however, with changes to .NET, it is no longer required.

An attempt was made to be more selective when applying the override,
for example using the IsDotNetBuild parameters, however, in each case
where this would have been used, the aliases that were being used were
already .NET aliases, so this didn't make any sense.  Since a .NET
build will already be being used.

With this in mind, the decision was made to simply remove all of the
overriding of the framework paths.

## Motivation and Context

While attempting to run a .NET build on Linux and Mac using
Chocolatey.Cake.Recipe, it was found that the builds fail.  However, if
the framework override was removed, the build worked as expected.

## Testing

1. Check out this PR, and copy the build files into the Chocolatey.Cake.Recipe package folder for Chocolatey CLI
1. Run .\build.bat
1. Ensure that build runs successfully
1. Other changes can really only be asserted once updated to run on actual project

### Operating Systems Testing

- Dev VM 4

## Change Types Made

* [x] Bug fix (non-breaking change).
* [ ] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [x] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #288 