### PR TITLE
(#292) Add GitReleaseManager artifact publishing

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/addins.cake
+++ b/Chocolatey.Cake.Recipe/Content/addins.cake
@@ -50,6 +50,9 @@
 #addin nuget:?package=Cake.Issues.PullRequests&version=0.7.0
 #addin nuget:?package=Cake.Issues.PullRequests.AppVeyor&version=0.7.0
 
+// Not really an addin, but needed to be able to query for GitHub releases
+#addin nuget:?package=Octokit&version=14.0.0
+
 Action<string, IDictionary<string, string>> RequireAddin = (code, envVars) => {
     var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));
     try

--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -484,11 +484,13 @@ BuildParameters.Tasks.DefaultTask = Task("Default")
 BuildParameters.Tasks.ContinuousIntegrationTask = Task("CI")
     .IsDependentOn("Publish-PreRelease-Packages")
     .IsDependentOn("Publish-Release-Packages")
+    .IsDependentOn("Publish-Public-Artifacts")
     .IsDependentOn("Publish-AWS-Lambdas")
     .Finally(() =>
 {
     if (publishingError)
     {
+        Error("Detected publishing error, throwing additional exception.");
         throw new Exception("An error occurred during the publishing of " + BuildParameters.Title + ".  All publishing tasks have been attempted.");
     }
 });

--- a/Chocolatey.Cake.Recipe/Content/packages.cake
+++ b/Chocolatey.Cake.Recipe/Content/packages.cake
@@ -300,7 +300,6 @@ public void PushChocolateyPackages(ICakeContext context, bool isRelease, List<Pa
 
                     // Push the package.
                     context.ChocolateyPush(nupkgFile, chocolateyPushSettings);
-                    BuildParameters.PublishProvider.AddArtifact(nupkgFile);
                 }
             }
             else
@@ -365,7 +364,6 @@ public void PushNuGetPackages(ICakeContext context, bool isRelease, List<Package
 
                     // Push the package.
                     context.NuGetPush(nupkgFile, nugetPushSettings);
-                    BuildParameters.PublishProvider.AddArtifact(nupkgFile);
                 }
             }
             else
@@ -382,14 +380,20 @@ public void PushNuGetPackages(ICakeContext context, bool isRelease, List<Package
 
 BuildParameters.Tasks.PackageTask = Task("Package")
     .IsDependentOn("Export-Release-Notes")
-    .Does(() => {
+    .Does(async () => {
         foreach (var nuGetPackage in GetFiles(BuildParameters.Paths.Directories.NuGetPackages + BuildParameters.NuGetNupkgGlobbingPattern))
         {
+            // Upload the NuGet package to the build provider for internal storage.
             BuildParameters.BuildProvider.UploadArtifact(nuGetPackage);
+            // Add the NuGet package to the publish provider for later publishing.
+            await BuildParameters.PublishProvider.AddArtifactAsync(ArtifactType.NuGetPackage, nuGetPackage);
         }
 
         foreach (var chocolateyPackage in GetFiles(BuildParameters.Paths.Directories.ChocolateyPackages + BuildParameters.ChocolateyNupkgGlobbingPattern))
         {
+            // Upload the Chocolatey package to the build provider for internal storage.
             BuildParameters.BuildProvider.UploadArtifact(chocolateyPackage);
+            // Add the Chocolatey package to the publish provider for later publishing.
+            await BuildParameters.PublishProvider.AddArtifactAsync(ArtifactType.ChocolateyPackage, chocolateyPackage);
         }
 });

--- a/Chocolatey.Cake.Recipe/Content/packages.cake
+++ b/Chocolatey.Cake.Recipe/Content/packages.cake
@@ -300,6 +300,7 @@ public void PushChocolateyPackages(ICakeContext context, bool isRelease, List<Pa
 
                     // Push the package.
                     context.ChocolateyPush(nupkgFile, chocolateyPushSettings);
+                    BuildParameters.PublishProvider.AddArtifact(nupkgFile);
                 }
             }
             else
@@ -364,6 +365,7 @@ public void PushNuGetPackages(ICakeContext context, bool isRelease, List<Package
 
                     // Push the package.
                     context.NuGetPush(nupkgFile, nugetPushSettings);
+                    BuildParameters.PublishProvider.AddArtifact(nupkgFile);
                 }
             }
             else

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -31,11 +31,13 @@ public static class BuildParameters
         return arguments;
     };
 
+    private static AggregatePublishProvider _publishProvider = new AggregatePublishProvider();
+
     public static BranchType BranchType { get; private set; }
     public static PlatformFamily BuildAgentOperatingSystem { get; private set; }
     public static string BuildCounter { get; private set; }
     public static IBuildProvider BuildProvider { get; private set; }
-    public static IPublishProvider PublishProvider { get; private set; }
+    public static IPublishProvider PublishProvider => _publishProvider;
     public static Cake.Core.Configuration.ICakeConfiguration CakeConfiguration { get; private set; }
 
     public static string CertificateAlgorithm { get; private set; }
@@ -163,6 +165,43 @@ public static class BuildParameters
         Tasks = new BuildTasks();
     }
 
+    /// <summary>
+    /// Registers the GitHub publish provider for public release artifacts.
+    /// </summary>
+    /// <param name="context">The Cake context.</param>
+    /// <remarks>
+    /// Public artifacts are release assets intended for external consumption, such as files published to GitHub Releases,
+    /// NuGet feeds, or Chocolatey feeds. Calling this method makes GitHub Releases available as a public artifact destination.
+    /// </remarks>
+    public static void AddGitHubPublishProvider(ICakeContext context)
+    {
+        if (context == null)
+        {
+            throw new ArgumentNullException(nameof(context));
+        }
+
+        AddPublishProvider(new GitHubPublishProvider(context));
+    }
+
+    /// <summary>
+    /// Registers a publish provider for public release artifacts.
+    /// </summary>
+    /// <param name="context">The Cake context.</param>
+    /// <param name="publishProvider">The publish provider to register.</param>
+    /// <remarks>
+    /// Use this overload to register custom destinations while keeping artifact selection and publishing coordinated
+    /// through <see cref="BuildParameters.PublishProvider"/>.
+    /// </remarks>
+    public static void AddPublishProvider(IPublishProvider publishProvider)
+    {
+        if (publishProvider == null)
+        {
+            throw new ArgumentNullException(nameof(publishProvider));
+        }
+
+        _publishProvider.AddPublishProvider(publishProvider);
+    }
+
     public static void SetBuildVersion(BuildVersion version)
     {
         Version  = version;
@@ -209,7 +248,6 @@ public static class BuildParameters
         context.Information("ProductComVisible: {0}", ProductComVisible);
         context.Information("ProductClsCompliant: {0}", ProductClsCompliant);
         context.Information("ProductCompany: {0}", ProductCompany);
-        context.Information("PublishProvider: {0}", PublishProvider.Name);
 
         if (ProductCustomAttributes != null)
         {
@@ -288,6 +326,7 @@ public static class BuildParameters
         context.Information("UnitTestAssemblyFilePattern: {0}", UnitTestAssemblyFilePattern);
         context.Information("UnitTestAssemblyProjectPattern: {0}", UnitTestAssemblyProjectPattern);
         context.Information("UseChocolateyGuiStrongNameKey: {0}", UseChocolateyGuiStrongNameKey);
+        context.Information("PublishProvider: {0}", PublishProvider.Name);
 
         context.Information("------------------------------------------------------------------------------------------");
     }
@@ -380,7 +419,6 @@ public static class BuildParameters
         bool shouldRunPSScriptAnalyzer = true,
         bool shouldStrongNameOutputAssemblies = true,
         bool shouldStrongNameSignDependentAssemblies = true,
-        bool shouldPublishPublicArtifacts = true,
         Func<BuildVersion, object[]> slackMessageArguments = null,
         DirectoryPath solutionDirectoryPath = null,
         FilePath solutionFilePath = null,
@@ -395,7 +433,7 @@ public static class BuildParameters
         string unitTestAssemblyFilePattern = null,
         string unitTestAssemblyProjectPattern = null,
         bool useChocolateyGuiStrongNameKey = false,
-        PublishProviderType publishProvider = PublishProviderType.None
+        bool shouldPublishPublicArtifacts = true
         )
     {
         if (context == null)
@@ -478,7 +516,6 @@ public static class BuildParameters
         ResharperSettingsFileName = resharperSettingsFileName ?? string.Format("{0}.sln.DotSettings", title);
         RestorePackagesDirectory = restorePackagesDirectory;
         ShouldAuthenticodeSignMsis = shouldAuthenticodeSignMsis;
-        PublishProvider = GetPublishProvider(context, publishProvider);
 
         if (context.HasArgument("shouldAuthenticodeSignMsis"))
         {

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -35,6 +35,7 @@ public static class BuildParameters
     public static PlatformFamily BuildAgentOperatingSystem { get; private set; }
     public static string BuildCounter { get; private set; }
     public static IBuildProvider BuildProvider { get; private set; }
+    public static IPublishProvider PublishProvider { get; private set; }
     public static Cake.Core.Configuration.ICakeConfiguration CakeConfiguration { get; private set; }
 
     public static string CertificateAlgorithm { get; private set; }
@@ -109,6 +110,7 @@ public static class BuildParameters
     public static bool ShouldPublishAwsLambdas { get; private set; }
     public static bool ShouldPublishPreReleasePackages { get; private set; }
     public static bool ShouldPublishReleasePackages { get; private set; }
+    public static bool ShouldPublishPublicArtifacts { get; private set; }
     public static bool ShouldReportCodeCoverageMetrics { get; private set; }
     public static bool ShouldReportUnitTestResults { get; private set; }
     public static bool ShouldRunAnalyze { get; private set; }
@@ -207,6 +209,7 @@ public static class BuildParameters
         context.Information("ProductComVisible: {0}", ProductComVisible);
         context.Information("ProductClsCompliant: {0}", ProductClsCompliant);
         context.Information("ProductCompany: {0}", ProductCompany);
+        context.Information("PublishProvider: {0}", PublishProvider.Name);
 
         if (ProductCustomAttributes != null)
         {
@@ -239,6 +242,7 @@ public static class BuildParameters
         context.Information("ShouldPostToTwitter: {0}", BuildParameters.ShouldPostToTwitter);
         context.Information("ShouldPublishAwsLambdas: {0}", BuildParameters.ShouldPublishAwsLambdas);
         context.Information("ShouldPublishPreReleasePackages: {0}", BuildParameters.ShouldPublishPreReleasePackages);
+        context.Information("ShouldPublishPublicArtifacts: {0}", BuildParameters.ShouldPublishPublicArtifacts);
         context.Information("ShouldPublishReleasePackages: {0}", BuildParameters.ShouldPublishReleasePackages);
         context.Information("ShouldReportCodeCoverageMetrics: {0}", BuildParameters.ShouldReportCodeCoverageMetrics);
         context.Information("ShouldReportUnitTestResults: {0}", BuildParameters.ShouldReportUnitTestResults);
@@ -376,6 +380,7 @@ public static class BuildParameters
         bool shouldRunPSScriptAnalyzer = true,
         bool shouldStrongNameOutputAssemblies = true,
         bool shouldStrongNameSignDependentAssemblies = true,
+        bool shouldPublishPublicArtifacts = true,
         Func<BuildVersion, object[]> slackMessageArguments = null,
         DirectoryPath solutionDirectoryPath = null,
         FilePath solutionFilePath = null,
@@ -389,7 +394,8 @@ public static class BuildParameters
         Func<BuildVersion, object[]> twitterMessageArguments = null,
         string unitTestAssemblyFilePattern = null,
         string unitTestAssemblyProjectPattern = null,
-        bool useChocolateyGuiStrongNameKey = false
+        bool useChocolateyGuiStrongNameKey = false,
+        PublishProviderType publishProvider = PublishProviderType.None
         )
     {
         if (context == null)
@@ -472,6 +478,7 @@ public static class BuildParameters
         ResharperSettingsFileName = resharperSettingsFileName ?? string.Format("{0}.sln.DotSettings", title);
         RestorePackagesDirectory = restorePackagesDirectory;
         ShouldAuthenticodeSignMsis = shouldAuthenticodeSignMsis;
+        PublishProvider = GetPublishProvider(context, publishProvider);
 
         if (context.HasArgument("shouldAuthenticodeSignMsis"))
         {
@@ -756,6 +763,13 @@ public static class BuildParameters
         if (context.HasArgument("shouldStrongNameSignDependentAssemblies"))
         {
             ShouldStrongNameSignDependentAssemblies = context.Argument<bool>("shouldStrongNameSignDependentAssemblies");
+        }
+
+        ShouldPublishPublicArtifacts = shouldPublishPublicArtifacts;
+
+        if (context.HasArgument("shouldPublishPublicArtifacts"))
+        {
+            ShouldPublishPublicArtifacts = context.Argument<bool>("shouldPublishPublicArtifacts");
         }
 
         SlackMessageArguments = slackMessageArguments ?? _defaultNotificationArguments;

--- a/Chocolatey.Cake.Recipe/Content/publishProvider.cake
+++ b/Chocolatey.Cake.Recipe/Content/publishProvider.cake
@@ -1,0 +1,160 @@
+using Octokit;
+
+BuildParameters.Tasks.PublishPublicArtifactsTask = Task("Publish-Public-Artifacts")
+    .IsDependentOn("Build-MSI")
+    .IsDependentOn("Publish-Release-Packages")
+    .WithCriteria(() => BuildParameters.ShouldPublishPublicArtifacts, "Skipping because publishing of public artifacts is not enabled")
+    .WithCriteria(() => !BuildParameters.IsLocalBuild || BuildParameters.ForceContinuousIntegration, "Skipping because this is a local build, and force isn't being applied")
+    .WithCriteria(() => !BuildParameters.IsPullRequest, "Skipping because current build is from a Pull Request")
+    .WithCriteria(() => BuildParameters.IsTagged, "Skipping because current commit is not tagged")
+    .Does(async () =>
+    {
+        var provider = BuildParameters.PublishProvider;
+
+        await provider.PublishArtifactsAsync();
+    })
+    .OnError(exception =>
+    {
+        Error(exception.Message);
+        Information("Publish-Public-Artifacts Task failed, but continuing with next Task...");
+        publishingError = true;
+    });
+
+public enum PublishProviderType
+{
+    None,
+    GitHub,
+}
+
+public interface IPublishProvider
+{
+    string Name { get; }
+
+    void AddArtifact(params FilePath[] artifactPaths);
+
+    Task<bool> CanPublishArtifactsAsync();
+
+    Task PublishArtifactsAsync();
+}
+
+public static IPublishProvider GetPublishProvider(ICakeContext context, PublishProviderType providerType)
+{
+    switch (providerType)
+    {
+        case PublishProviderType.GitHub:
+            return new GitHubPublishProvider(context);
+
+        default:
+            return new NullPublishProvider(context);
+    }
+}
+
+internal class NullPublishProvider : IPublishProvider
+{
+    private readonly ICakeContext _context;
+
+    public NullPublishProvider(ICakeContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public string Name { get; } = "None";
+
+    public void AddArtifact(params FilePath[] artifactPaths)
+    {
+        // Nothing to do, we aren't publishing anything in this case.
+    }
+
+    public Task<bool> CanPublishArtifactsAsync()
+    {
+        return System.Threading.Tasks.Task.FromResult(false);
+    }
+
+    public Task PublishArtifactsAsync()
+    {
+        _context.Information("[NullPublishProvider] No artifacts possible to publish.");
+        return System.Threading.Tasks.Task.CompletedTask;
+    }
+}
+
+internal class GitHubPublishProvider : IPublishProvider
+{
+    private readonly ICakeContext _context;
+    private readonly List<FilePath> _publishArtifacts = new List<FilePath>();
+
+    public GitHubPublishProvider(ICakeContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public string Name { get; } = "GitHub";
+
+    public void AddArtifact(params FilePath[] artifactPaths)
+    {
+        _publishArtifacts.AddRange(artifactPaths);
+    }
+
+    public async Task<bool> CanPublishArtifactsAsync()
+    {
+        var credentials = GitReleaseManagerCredentials.FetchCredentials(_context);
+
+        if (string.IsNullOrWhiteSpace(credentials.Token))
+        {
+            _context.Information("No GitReleaseManager Credentials found, unable to publish public artifacts.");
+            return false;
+        }
+
+        var client = new GitHubClient(new Octokit.ProductHeaderValue("Chocolatey.Cake.Recipe"))
+        {
+            Credentials = new Credentials(credentials.Token),
+        };
+
+        try
+        {
+            var release = await client.Repository.Release.Get(BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.Milestone);
+
+            if (release == null)
+            {
+                _context.Warning("No GitHub release exists with the tag {0}, unable to publish public artifacts.", BuildParameters.Version.Milestone);
+                return false;
+            }
+
+            return true;
+        }
+        catch (NotFoundException)
+        {
+            _context.Warning("No GitHub release exists with the tag {0}, unable to publish public artifacts.", BuildParameters.Version.Milestone);
+            return false;
+        }
+    }
+
+    public async Task PublishArtifactsAsync()
+    {
+        if (!await CanPublishArtifactsAsync())
+        {
+            return;
+        }
+
+        var assets = string.Join(",", _publishArtifacts.Select(a => a.ToString()));
+
+        if (assets.Length == 0)
+        {
+            return;
+        }
+
+        var addAssetsSettings = new GitReleaseManagerAddAssetsSettings();
+
+        if (_context.EnvironmentVariable("CI") != null || _context.EnvironmentVariable("TEAMCITY_VERSION") != null)
+        {
+            addAssetsSettings.ArgumentCustomization = args => args.Append("--ci");
+        }
+
+        var gitReleaseManagerCredentials = GitReleaseManagerCredentials.FetchCredentials(_context);
+        var tagName = BuildParameters.Version.Milestone;
+        _context.Information("Using Tag Name '{0}' for publishing.", tagName);
+
+        _context.RequireToolEx(BuildParameters.IsDotNetBuild || BuildParameters.PreferDotNetGlobalToolUsage ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, (context) => {
+            context.GitReleaseManagerAddAssets(gitReleaseManagerCredentials.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, tagName, assets, addAssetsSettings);
+        });
+    }
+}

--- a/Chocolatey.Cake.Recipe/Content/publishProvider.cake
+++ b/Chocolatey.Cake.Recipe/Content/publishProvider.cake
@@ -2,7 +2,7 @@ using Octokit;
 
 BuildParameters.Tasks.PublishPublicArtifactsTask = Task("Publish-Public-Artifacts")
     .IsDependentOn("Build-MSI")
-    .IsDependentOn("Publish-Release-Packages")
+    .IsDependentOn("Package")
     .WithCriteria(() => BuildParameters.ShouldPublishPublicArtifacts, "Skipping because publishing of public artifacts is not enabled")
     .WithCriteria(() => !BuildParameters.IsLocalBuild || BuildParameters.ForceContinuousIntegration, "Skipping because this is a local build, and force isn't being applied")
     .WithCriteria(() => !BuildParameters.IsPullRequest, "Skipping because current build is from a Pull Request")
@@ -11,6 +11,9 @@ BuildParameters.Tasks.PublishPublicArtifactsTask = Task("Publish-Public-Artifact
     {
         var provider = BuildParameters.PublishProvider;
 
+        // Publish any artifacts that have been added to the provider.
+        // This will only publish artifacts that the provider can publish, and will skip any artifacts that cannot be published by the provider.
+        // We expect all artifacts to have been added to the provider in the "Build-MSI" and "Package" tasks, or explicitly by calling the BuildParameters.PublishProvider.AddArtifactAsync() method in a custom task.
         await provider.PublishArtifactsAsync();
     })
     .OnError(exception =>
@@ -20,85 +23,244 @@ BuildParameters.Tasks.PublishPublicArtifactsTask = Task("Publish-Public-Artifact
         publishingError = true;
     });
 
-public enum PublishProviderType
+/// <summary>
+/// Defines the type of artifact to be published to public repositories or locations.
+/// This is used to determine if the publish provider can publish the artifact type, and to provide additional information for logging purposes.
+/// </summary>
+public enum ArtifactType
 {
-    None,
-    GitHub,
+    NuGetPackage,
+    ChocolateyPackage,
+    Other,
 }
 
+/// <summary>
+/// Defines the interface for a publish provider that can publish artifacts to public repositories or locations.
+/// </summary>
+/// <remarks>
+/// A publish provider is not to be confused with standard uploading of artifacts to a build server or other internal locations.
+/// A publish provider is intended to publish artifacts to public repositories or locations, such as NuGet.org, Chocolatey.org, GitHub Releases, etc.
+/// (Only GitHub Releases is currently supported, but more providers may be added in the future.)
+/// </remarks>
 public interface IPublishProvider
 {
+    /// <summary>
+    /// Gets the name of the publish provider.
+    /// </summary>
     string Name { get; }
 
-    void AddArtifact(params FilePath[] artifactPaths);
+    /// <summary>
+    /// Adds the specified artifact paths to the list of artifacts to be published by the provider.
+    /// </summary>
+    /// <param name="artifactType">The type of artifact to be published.</param>
+    /// <param name="artifactPaths">The paths of the artifacts to be published.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    Task AddArtifactAsync(ArtifactType artifactType, params FilePath[] artifactPaths);
 
-    Task<bool> CanPublishArtifactsAsync();
+    /// <summary>
+    /// Determines whether the provider can publish artifacts of the specified type.
+    /// </summary>
+    /// <param name="artifactType">The type of artifact to be published.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains a boolean value indicating whether the provider can publish artifacts of the specified type.</returns>
+    Task<bool> CanPublishArtifactsAsync(ArtifactType artifactType = ArtifactType.Other);
 
+    /// <summary>
+    /// Publishes the artifacts that have been added to the provider.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous operation.</returns>
     Task PublishArtifactsAsync();
 }
 
-public static IPublishProvider GetPublishProvider(ICakeContext context, PublishProviderType providerType)
+/// <summary>
+/// Provides a base implementation of the <see cref="IPublishProvider"/> interface.
+/// </summary>
+internal abstract class PublishProviderBase : IPublishProvider
 {
-    switch (providerType)
-    {
-        case PublishProviderType.GitHub:
-            return new GitHubPublishProvider(context);
+    protected readonly ICakeContext _context;
 
-        default:
-            return new NullPublishProvider(context);
-    }
-}
-
-internal class NullPublishProvider : IPublishProvider
-{
-    private readonly ICakeContext _context;
-
-    public NullPublishProvider(ICakeContext context)
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PublishProviderBase"/> class.
+    /// </summary>
+    /// <param name="context">The Cake context.</param>
+    protected PublishProviderBase(ICakeContext context)
     {
         _context = context ?? throw new ArgumentNullException(nameof(context));
     }
 
-    public string Name { get; } = "None";
+    /// <inheritdoc/>
+    public abstract string Name { get; }
 
-    public void AddArtifact(params FilePath[] artifactPaths)
+    protected IDictionary<string, FilePath> ArtifactsToPublish { get; } = new Dictionary<string, FilePath>(StringComparer.OrdinalIgnoreCase);
+
+    /// <inheritdoc/>
+    public virtual async Task AddArtifactAsync(ArtifactType artifactType, params FilePath[] artifactPaths)
     {
-        // Nothing to do, we aren't publishing anything in this case.
+        if (artifactPaths == null || artifactPaths.Length == 0)
+        {
+            return;
+        }
+
+        if (!await CanPublishArtifactsAsync(artifactType))
+        {
+            return;
+        }
+
+        foreach (var artifactPath in artifactPaths)
+        {
+            if (artifactPath == null || string.IsNullOrWhiteSpace(artifactPath.FullPath))
+            {
+                continue;
+            }
+
+            ArtifactsToPublish[artifactPath.FullPath] = artifactPath;
+        }
     }
 
-    public Task<bool> CanPublishArtifactsAsync()
+    /// <inheritdoc/>
+    public abstract Task<bool> CanPublishArtifactsAsync(ArtifactType artifactType = ArtifactType.Other);
+
+    /// <inheritdoc/>
+    public abstract Task PublishArtifactsAsync();
+}
+
+/// <summary>
+/// Represents a publish provider that aggregates multiple publish providers and delegates publishing tasks to them.
+/// </summary>
+public sealed class AggregatePublishProvider : IPublishProvider
+{
+    private readonly List<IPublishProvider> _publishProviders = new List<IPublishProvider>();
+
+    /// <inheritdoc/>
+    public string Name => _publishProviders.Count == 0
+        ? "None"
+        : string.Join(", ", _publishProviders.Select(p => p.Name));
+
+    /// <inheritdoc/>
+    public async Task AddArtifactAsync(ArtifactType artifactType, params FilePath[] artifactPaths)
     {
-        return System.Threading.Tasks.Task.FromResult(false);
+        if (artifactPaths == null || artifactPaths.Length == 0)
+        {
+            return;
+        }
+
+        foreach (var provider in _publishProviders)
+        {
+            await provider.AddArtifactAsync(artifactType, artifactPaths);
+        }
     }
 
-    public Task PublishArtifactsAsync()
+    /// <summary>
+    /// Adds a publish provider to the aggregate provider.
+    /// </summary>
+    /// <param name="publishProvider">The publish provider to add.</param>
+    /// <exception cref="ArgumentNullException">Thrown when the <paramref name="publishProvider"/> is null.</exception>
+    public void AddPublishProvider(IPublishProvider publishProvider)
     {
-        _context.Information("[NullPublishProvider] No artifacts possible to publish.");
+        if (publishProvider == null)
+        {
+            throw new ArgumentNullException(nameof(publishProvider));
+        }
+
+        _publishProviders.Add(publishProvider);
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> CanPublishArtifactsAsync(ArtifactType artifactType = ArtifactType.Other)
+    {
+        if (_publishProviders.Count == 0)
+        {
+            return false;
+        }
+
+        foreach (var provider in _publishProviders)
+        {
+            if (await provider.CanPublishArtifactsAsync(artifactType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <inheritdoc/>
+    public async Task PublishArtifactsAsync()
+    {
+        foreach (var provider in _publishProviders)
+        {
+            await provider.PublishArtifactsAsync();
+        }
+    }
+}
+
+/// <summary>
+/// Represents a publish provider that publishes artifacts to GitHub Releases.
+/// </summary>
+/// <remarks>
+/// This provider uses the GitReleaseManager tool to publish artifacts to GitHub Releases. It requires a valid GitHub token to be set in the environment variables or in the Cake context.
+/// All artifact types are supported by this provider, and it will attempt to publish all artifacts that have been added to it.
+/// </remarks>
+internal class GitHubPublishProvider : PublishProviderBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GitHubPublishProvider"/> class.
+    /// </summary>
+    /// <param name="context">The Cake context.</param>
+    public GitHubPublishProvider(ICakeContext context)
+      : base(context)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override string Name { get; } = "GitHub";
+
+    /// <inheritdoc/>
+    public override Task<bool> CanPublishArtifactsAsync(ArtifactType artifactType = ArtifactType.Other)
+    {
+        return System.Threading.Tasks.Task.FromResult(HasAvailableGitHubRelease());
+    }
+
+    /// <inheritdoc/>
+    public override Task PublishArtifactsAsync()
+    {
+        if (!HasAvailableGitHubRelease())
+        {
+            return System.Threading.Tasks.Task.CompletedTask;
+        }
+
+        var assets = string.Join(",", ArtifactsToPublish.Values.Select(a => a.ToString()));
+
+        if (assets.Length == 0)
+        {
+            _context.Verbose("No artifacts to publish using {0} provider.", Name);
+
+            return System.Threading.Tasks.Task.CompletedTask;
+        }
+
+        var addAssetsSettings = new GitReleaseManagerAddAssetsSettings();
+
+        if (_context.EnvironmentVariable("CI") != null || _context.EnvironmentVariable("TEAMCITY_VERSION") != null)
+        {
+            addAssetsSettings.ArgumentCustomization = args => args.Append("--ci");
+        }
+
+        var gitReleaseManagerCredentials = GitReleaseManagerCredentials.FetchCredentials(_context);
+        var tagName = BuildParameters.Version.Milestone;
+        _context.Information("Using Tag Name '{0}' for publishing.", tagName);
+        _context.Information("Adding {0} asset(s) to GitHub release.", ArtifactsToPublish.Count);
+
+        _context.RequireToolEx(BuildParameters.IsDotNetBuild || BuildParameters.PreferDotNetGlobalToolUsage ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, (context) => {
+            context.GitReleaseManagerAddAssets(gitReleaseManagerCredentials.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, tagName, assets, addAssetsSettings);
+        });
+
         return System.Threading.Tasks.Task.CompletedTask;
     }
-}
 
-internal class GitHubPublishProvider : IPublishProvider
-{
-    private readonly ICakeContext _context;
-    private readonly List<FilePath> _publishArtifacts = new List<FilePath>();
-
-    public GitHubPublishProvider(ICakeContext context)
+    private bool HasAvailableGitHubRelease()
     {
-        _context = context ?? throw new ArgumentNullException(nameof(context));
-    }
+        var gitReleaseManagerCredentials = GitReleaseManagerCredentials.FetchCredentials(_context);
 
-    public string Name { get; } = "GitHub";
-
-    public void AddArtifact(params FilePath[] artifactPaths)
-    {
-        _publishArtifacts.AddRange(artifactPaths);
-    }
-
-    public async Task<bool> CanPublishArtifactsAsync()
-    {
-        var credentials = GitReleaseManagerCredentials.FetchCredentials(_context);
-
-        if (string.IsNullOrWhiteSpace(credentials.Token))
+        if (string.IsNullOrWhiteSpace(gitReleaseManagerCredentials.Token))
         {
             _context.Information("No GitReleaseManager Credentials found, unable to publish public artifacts.");
             return false;
@@ -106,12 +268,12 @@ internal class GitHubPublishProvider : IPublishProvider
 
         var client = new GitHubClient(new Octokit.ProductHeaderValue("Chocolatey.Cake.Recipe"))
         {
-            Credentials = new Credentials(credentials.Token),
+            Credentials = new Credentials(gitReleaseManagerCredentials.Token),
         };
 
         try
         {
-            var release = await client.Repository.Release.Get(BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.Milestone);
+            var release = client.Repository.Release.Get(BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, BuildParameters.Version.Milestone).GetAwaiter().GetResult();
 
             if (release == null)
             {
@@ -126,35 +288,17 @@ internal class GitHubPublishProvider : IPublishProvider
             _context.Warning("No GitHub release exists with the tag {0}, unable to publish public artifacts.", BuildParameters.Version.Milestone);
             return false;
         }
-    }
-
-    public async Task PublishArtifactsAsync()
-    {
-        if (!await CanPublishArtifactsAsync())
+        catch (AuthorizationException exception)
         {
-            return;
+            var message = string.Format("GitHub credentials are invalid or unauthorized, unable to publish public artifacts. {0}", exception.Message);
+
+            throw new Exception(message, exception);
         }
-
-        var assets = string.Join(",", _publishArtifacts.Select(a => a.ToString()));
-
-        if (assets.Length == 0)
+        catch (ForbiddenException exception)
         {
-            return;
+            var message = string.Format("GitHub API access was forbidden or rate-limited, unable to publish public artifacts. {0}", exception.Message);
+
+            throw new Exception(message, exception);
         }
-
-        var addAssetsSettings = new GitReleaseManagerAddAssetsSettings();
-
-        if (_context.EnvironmentVariable("CI") != null || _context.EnvironmentVariable("TEAMCITY_VERSION") != null)
-        {
-            addAssetsSettings.ArgumentCustomization = args => args.Append("--ci");
-        }
-
-        var gitReleaseManagerCredentials = GitReleaseManagerCredentials.FetchCredentials(_context);
-        var tagName = BuildParameters.Version.Milestone;
-        _context.Information("Using Tag Name '{0}' for publishing.", tagName);
-
-        _context.RequireToolEx(BuildParameters.IsDotNetBuild || BuildParameters.PreferDotNetGlobalToolUsage ? ToolSettings.GitReleaseManagerGlobalTool : ToolSettings.GitReleaseManagerTool, (context) => {
-            context.GitReleaseManagerAddAssets(gitReleaseManagerCredentials.Token, BuildParameters.RepositoryOwner, BuildParameters.RepositoryName, tagName, assets, addAssetsSettings);
-        });
     }
 }

--- a/Chocolatey.Cake.Recipe/Content/sign.cake
+++ b/Chocolatey.Cake.Recipe/Content/sign.cake
@@ -200,7 +200,7 @@ BuildParameters.Tasks.SignMsisTask = Task("Sign-Msis")
     .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping due to not running on Windows")
     .WithCriteria(() => (!string.IsNullOrWhiteSpace(BuildParameters.CertificateFilePath) && FileExists(BuildParameters.CertificateFilePath)) || BuildSystem.IsRunningOnTeamCity, "Skipping because unable to find certificate, and not running on TeamCity")
     .WithCriteria(() => BuildParameters.ShouldAuthenticodeSignMsis, "Skipping since authenticode signing of msi's has been disabled")
-    .Does(() =>
+    .Does(async () =>
 {
     if (BuildParameters.GetMsisToSign != null)
     {
@@ -237,7 +237,9 @@ BuildParameters.Tasks.SignMsisTask = Task("Sign-Msis")
             if (FileExists(msiToSign))
             {
                 BuildParameters.BuildProvider.UploadArtifact(msiToSign);
-                BuildParameters.PublishProvider.AddArtifact(msiToSign);
+                // Add the signed MSI to the list of artifacts to be published.
+                // NOTE: We do this here to ensure that only the signed MSI is published, and not the unsigned one.
+                await BuildParameters.PublishProvider.AddArtifactAsync(ArtifactType.Other, msiToSign);
             }
         }
     }

--- a/Chocolatey.Cake.Recipe/Content/sign.cake
+++ b/Chocolatey.Cake.Recipe/Content/sign.cake
@@ -237,6 +237,7 @@ BuildParameters.Tasks.SignMsisTask = Task("Sign-Msis")
             if (FileExists(msiToSign))
             {
                 BuildParameters.BuildProvider.UploadArtifact(msiToSign);
+                BuildParameters.PublishProvider.AddArtifact(msiToSign);
             }
         }
     }

--- a/Chocolatey.Cake.Recipe/Content/tasks.cake
+++ b/Chocolatey.Cake.Recipe/Content/tasks.cake
@@ -60,6 +60,7 @@ public class BuildTasks
     public CakeTaskBuilder DotNetPackTask { get; set; }
     public CakeTaskBuilder PublishPreReleasePackagesTask { get; set; }
     public CakeTaskBuilder PublishReleasePackagesTask { get; set; }
+    public CakeTaskBuilder PublishPublicArtifactsTask { get; set; }
     public CakeTaskBuilder PublishAwsLambdasTask { get; set; }
 
     // Testing Tasks

--- a/Chocolatey.Cake.Recipe/Content/tools.cake
+++ b/Chocolatey.Cake.Recipe/Content/tools.cake
@@ -18,7 +18,12 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 Action<string, Action> RequireTool = (tool, action) => {
-    var script = MakeAbsolute(File(string.Format("./{0}.cake", Guid.NewGuid())));
+    RequireToolEx(Context, tool, (context) => action());
+};
+
+static void RequireToolEx(this ICakeContext context, string tool, Action<ICakeContext> action)
+{
+    var script = context.MakeAbsolute(context.File(string.Format("./{0}.cake", Guid.NewGuid())));
     try
     {
         var arguments = new Dictionary<string, string>();
@@ -32,7 +37,7 @@ Action<string, Action> RequireTool = (tool, action) => {
         }
 
         System.IO.File.WriteAllText(script.FullPath, tool);
-        CakeExecuteScript(script,
+        context.CakeExecuteScript(script,
             new CakeSettings
             {
                 Arguments = arguments
@@ -40,14 +45,14 @@ Action<string, Action> RequireTool = (tool, action) => {
     }
     finally
     {
-        if (FileExists(script))
+        if (context.FileExists(script))
         {
-            DeleteFile(script);
+            context.DeleteFile(script);
         }
     }
 
-    action();
-};
+    action(context);
+}
 
 Action<string, string, Action> RequirePSModule = (module, requiredVersion, action) => {
     var powerShellModuleInstallationScript = GetFiles("./tools/Chocolatey.Cake.Recipe*/Content/install-module.ps1").FirstOrDefault();


### PR DESCRIPTION
## Description Of Changes

- Create GitHubPublishProvider class implementing IPublishProvider interface for artifact management
- Add PublishProvider property to BuildParameters for provider selection
- Add ShouldPublishPublicArtifacts parameter to control artifact publishing behavior
- Integrate Publish-Public-Artifacts task into main publish pipeline
- Add logging for PublishProvider and ShouldPublishPublicArtifacts configuration
- Add check for whether the release exist or not before attempting to add assets to the release.

## Motivation and Context

Standardize artifact publishing through a consistent provider interface, enable automatic asset uploads to release pages on supported platforms, provide configuration flexibility for artifact publishing workflows, and ensure GitReleaseManager tool is properly loaded before execution.

## Testing

This was tested on soteria dev, and the result of the testing can be seen here. https://github.com/AdmiringWorm/recipe-test/releases/tag/2.0.1 (build: https://sra-soteria-dev-web.ch0.co/buildConfiguration/RecipeTestKim_Build/15781)

Unfortunately, not able to add any proper testing steps

### Operating Systems Testing

- Windows 11

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [x] PowerShell code changes: PowerShell v3 compatibility checked?
* [x] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #292
