### PR TITLE
(maint) Refactor library build output copy logic

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -225,9 +225,9 @@ public void CopyBuildOutput()
             continue;
         }
 
-        if (parsedProject.OutputPath == null || parsedProject.RootNameSpace == null || parsedProject.OutputType == null)
+        if (parsedProject.OutputPaths == null || parsedProject.OutputPaths.Length == 0 || parsedProject.RootNameSpace == null || parsedProject.OutputType == null)
         {
-            Information("OutputPath: {0}", parsedProject.OutputPath);
+            Information("OutputPaths: Null Or Empty");
             Information("RootNameSpace: {0}", parsedProject.RootNameSpace);
             Information("OutputType: {0}", parsedProject.OutputType);
             throw new Exception(string.Format("Unable to parse project file correctly: {0}", project.Path));
@@ -358,67 +358,64 @@ public void CopyBuildOutput()
             }
             else
             {
-                CopyFiles(GetFiles(parsedProject.OutputPath.FullPath + "/**/*"), outputFolder, true);
+                CopyFiles(GetFiles(parsedProject.OutputPaths[0].FullPath + "/**/*"), outputFolder, true);
             }
 
             continue;
         }
 
-        if (parsedProject.IsLibrary() && parsedProject.IsXUnitTestProject())
-        {
-            Information("Project has an output type of library and is an xUnit Test Project: {0}", parsedProject.AssemblyName);
-            var outputFolder = BuildParameters.Paths.Directories.PublishedxUnitTests.Combine(parsedProject.AssemblyName);
-            EnsureDirectoryExists(outputFolder);
-            CopyFiles(GetFiles(parsedProject.OutputPath.FullPath + "/**/*"), outputFolder, true);
-            continue;
-        }
-        else if (parsedProject.IsLibrary() && parsedProject.IsNUnitTestProject())
-        {
-            Information("Project has an output type of library and is a NUnit Test Project: {0}", parsedProject.AssemblyName);
-            var outputFolder = BuildParameters.Paths.Directories.PublishedNUnitTests.Combine(parsedProject.AssemblyName);
-            EnsureDirectoryExists(outputFolder);
-            CopyFiles(GetFiles(parsedProject.OutputPath.FullPath + "/**/*"), outputFolder, true);
-            continue;
-        }
-        else
-        {
-            Information("Project has an output type of library: {0}", parsedProject.AssemblyName);
+        CopyLibraryBuildOutput(parsedProject);
+    }
+}
 
-            var outputFolder = BuildParameters.Paths.Directories.PublishedLibraries.Combine(parsedProject.AssemblyName);
+private void CopyLibraryBuildOutput(CustomProjectParserResult parsedProject)
+{
+    DirectoryPath outputFolder = null;
 
-            if (parsedProject.IsVS2017ProjectFormat)
+    if (parsedProject.IsLibrary() && parsedProject.IsXUnitTestProject())
+    {
+        Information("Project has an output type of library and is an xUnit Test Project: {0}", parsedProject.AssemblyName);
+        outputFolder = BuildParameters.Paths.Directories.PublishedxUnitTests.Combine(parsedProject.AssemblyName);
+    }
+    else if (parsedProject.IsLibrary() && parsedProject.IsNUnitTestProject())
+    {
+        Information("Project has an output type of library and is a NUnit Test Project: {0}", parsedProject.AssemblyName);
+        outputFolder = BuildParameters.Paths.Directories.PublishedNUnitTests.Combine(parsedProject.AssemblyName);
+    }
+    else
+    {
+        Information("Project has an output type of library: {0}", parsedProject.AssemblyName);
+        outputFolder = BuildParameters.Paths.Directories.PublishedLibraries.Combine(parsedProject.AssemblyName);
+    }
+
+    if (parsedProject.IsVS2017ProjectFormat)
+    {
+        var msBuildSettings = new DotNetCoreMSBuildSettings()
+                    .WithProperty("Version", BuildParameters.Version.SemVersion)
+                    .WithProperty("AssemblyVersion", BuildParameters.Version.FileVersion)
+                    .WithProperty("FileVersion", BuildParameters.Version.FileVersion)
+                    .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
+                    .WithProperty("Copyright", BuildParameters.ProductCopyright);
+        
+        foreach (var targetFramework in parsedProject.NetCore.TargetFrameworks)
+        {
+            Information("Running dotnet publish for {0}...", parsedProject.ProjectFilePath.FullPath);
+
+            DotNetCorePublish(parsedProject.ProjectFilePath.FullPath, new DotNetCorePublishSettings
             {
-                var msBuildSettings = new DotNetCoreMSBuildSettings()
-                            .WithProperty("Version", BuildParameters.Version.SemVersion)
-                            .WithProperty("AssemblyVersion", BuildParameters.Version.FileVersion)
-                            .WithProperty("FileVersion",  BuildParameters.Version.FileVersion)
-                            .WithProperty("AssemblyInformationalVersion", BuildParameters.Version.InformationalVersion)
-                            .WithProperty("Copyright", BuildParameters.ProductCopyright);
-
-                foreach (var targetFramework in parsedProject.NetCore.TargetFrameworks)
-                {
-                    Information("Running dotnet publish for {0}...", project.Path.FullPath);
-
-                    DotNetCorePublish(project.Path.FullPath, new DotNetCorePublishSettings {
-                        OutputDirectory = outputFolder.Combine(targetFramework),
-
-                        Framework = targetFramework,
-                        Configuration = BuildParameters.Configuration,
-                        MSBuildSettings = msBuildSettings,
-                        NoRestore = true,
-                        NoBuild = true
-                    });
-                }
-            }
-            else
-            {
-                EnsureDirectoryExists(outputFolder);
-                Information(parsedProject.OutputPath.FullPath);
-                CopyFiles(GetFiles(parsedProject.OutputPath.FullPath + "/**/*"), outputFolder, true);
-            }
-
-            continue;
+                Framework = targetFramework,
+                Configuration = BuildParameters.Configuration,
+                MSBuildSettings = msBuildSettings,
+                NoRestore = true,
+                NoBuild = true
+            });
         }
+    }
+    else
+    {
+        EnsureDirectoryExists(outputFolder);
+        Information(parsedProject.OutputPaths[0].FullPath);
+        CopyFiles(GetFiles(parsedProject.OutputPaths[0].FullPath + "/**/*"), outputFolder, true);
     }
 }
 


### PR DESCRIPTION
## Description Of Changes

* Extracted library build output copying logic into a separate `CopyLibraryBuildOutput` method
* Replaced `OutputPath` property with `OutputPaths` array to support multiple target frameworks
* Updated null/empty validation to check `OutputPaths` array length
* Consolidated xUnit, NUnit, and library output handling into a single method
* Simplified Information logging for output paths

## Motivation and Context

Refactoring to reduce code duplication, improve readability, and support multiple output paths for different target frameworks while improving overall maintainability.
Additionally, remove deprecated calls to OutputPath and fix the logic for handling testing frameworks for VS2017+ CSProj formats.

## Testing

1. Build the changes in this PR.
2. Copy the resulting build artifacts to a different project that targets multiple target frameworks in test projects (and library).
3. Run the build script in the test project repository.
4. Verify no compilation errors are shown.
5. Verify the deprecated messages about the `OutputPath` is no longer present.
6. Once the build completes, verify the build artifacts for libraries, XUnit/NUnit tests have target frameworks.

### Operating Systems Testing

- Windows 11

## Change Types Made

* [x] Feature / Enhancement (non-breaking change).

## Change Checklist

* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

_Need to get one created_