### PR TITLE
(#298) Add ability to submit files to VirusTotal

### DIFF
--- a/Chocolatey.Cake.Recipe/Content/build.cake
+++ b/Chocolatey.Cake.Recipe/Content/build.cake
@@ -550,6 +550,8 @@ public class Builder
         BuildParameters.Tasks.PackageTask.IsDependentOn("Analyze");
         BuildParameters.Tasks.PackageTask.IsDependentOn("Create-Chocolatey-Packages");
         BuildParameters.Tasks.PackageTask.IsDependentOn("Create-NuGet-Packages");
+        BuildParameters.Tasks.SubmitToVirusTotalTask.IsDependentOn("Package");
+        BuildParameters.Tasks.ContinuousIntegrationTask.IsDependentOn("Submit-To-VirusTotal");
         BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Configuration-Builder");
         BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Obfuscate-Assemblies");
         BuildParameters.Tasks.CreateChocolateyPackagesTask.IsDependentOn("Sign-Assemblies");

--- a/Chocolatey.Cake.Recipe/Content/credentials.cake
+++ b/Chocolatey.Cake.Recipe/Content/credentials.cake
@@ -285,6 +285,31 @@ public class SonarQubeCredentials
     }
 }
 
+public class VirusTotalCredentials
+{
+    public string ApiKey { get; private set; }
+
+    public static VirusTotalCredentials FetchCredentials(ICakeContext context)
+    {
+        var apiKey = context.EnvironmentVariable(Environment.VirusTotalApiKeyVariable);
+
+        if (string.IsNullOrWhiteSpace(apiKey) && BuildParameters.IsLocalBuild)
+        {
+            context.Warning("The required API Key for submitting files to VirusTotal has not been provided.");
+            context.Warning("In future, this can be set using the {0} environment variable.", Environment.VirusTotalApiKeyVariable);
+
+            apiKey = context.Prompt("Enter API Key for VirusTotal:");
+        }
+
+        return new VirusTotalCredentials(apiKey);
+    }
+
+    public VirusTotalCredentials(string apiKey)
+    {
+        ApiKey = apiKey;
+    }
+}
+
 public class DockerCredentials
 {
     public string Server { get; private set; }

--- a/Chocolatey.Cake.Recipe/Content/environment.cake
+++ b/Chocolatey.Cake.Recipe/Content/environment.cake
@@ -35,6 +35,7 @@ public static class Environment
     public static string DockerUserVariable { get; private set; }
     public static string DockerPasswordVariable { get; private set; }
     public static string DockerServerVariable { get; private set; }
+    public static string VirusTotalApiKeyVariable { get; private set; }
 
     public static void SetVariableNames(
         string defaultPushSourceUrlVariable = null,
@@ -56,7 +57,8 @@ public static class Environment
         string sonarQubeUrlVariable = null,
         string dockerUserVariable = null,
         string dockerPasswordVariable = null,
-        string dockerServerVariable = null)
+        string dockerServerVariable = null,
+        string virusTotalApiKeyVariable = null)
     {
         DefaultPushSourceUrlVariable = defaultPushSourceUrlVariable ?? "NUGETDEVPUSH_SOURCE";
         DiscordWebHookUrlVariable = discordWebHookUrlVariable ?? "DISCORD_WEBHOOKURL";
@@ -78,5 +80,6 @@ public static class Environment
         DockerUserVariable = dockerUserVariable ?? "DOCKER_USER";
         DockerPasswordVariable = dockerPasswordVariable ?? "DOCKER_PASSWORD";
         DockerServerVariable = dockerServerVariable ?? "DOCKER_SERVER";
+        VirusTotalApiKeyVariable = virusTotalApiKeyVariable ?? "VIRUSTOTAL_API_KEY";
     }
 }

--- a/Chocolatey.Cake.Recipe/Content/modules.cake
+++ b/Chocolatey.Cake.Recipe/Content/modules.cake
@@ -15,3 +15,11 @@
 
 #module nuget:?package=Cake.BuildSystems.Module&version=0.3.1
 #module nuget:?package=Cake.DotNetTool.Module&version=0.4.0
+
+// Required so that the "#tool choco:" pre-processor directive can be
+// used to install Chocolatey packages, for example the vt-cli package
+// used by the Submit-To-VirusTotal task. A module has to exist on disk
+// before Cake runs, so unlike a tool it can't be installed on demand,
+// and therefore has to be declared here rather than being pulled in only
+// by the builds which need it.
+#module nuget:?package=Cake.Chocolatey.Module&version=0.3.0

--- a/Chocolatey.Cake.Recipe/Content/parameters.cake
+++ b/Chocolatey.Cake.Recipe/Content/parameters.cake
@@ -55,6 +55,7 @@ public static class BuildParameters
     public static Func<List<ILMergeConfig>> GetILMergeConfigs { get; private set; }
     public static Func<List<PSScriptAnalyzerSettings>> GetPSScriptAnalyzerSettings { get; private set; }
     public static Func<FilePathCollection> GetMsisToSign { get; private set; }
+    public static Func<FilePathCollection> GetFilesToSubmitToVirusTotal { get; private set; }
     public static Func<FilePathCollection> GetProjectsToPack { get; private set; }
     public static Func<FilePathCollection> GetScriptsToVerify { get; private set; }
     public static Func<FilePathCollection> GetScriptsToSign { get; private set; }
@@ -133,6 +134,7 @@ public static class BuildParameters
     public static bool ShouldRunPSScriptAnalyzer { get; private set; }
     public static bool ShouldStrongNameOutputAssemblies { get; private set; }
     public static bool ShouldStrongNameSignDependentAssemblies { get; private set; }
+    public static bool ShouldSubmitToVirusTotal { get; private set; }
     public static Func<BuildVersion, object[]> SlackMessageArguments { get; private set; }
     public static DirectoryPath SolutionDirectoryPath { get; private set; }
     public static FilePath SolutionFilePath { get; private set; }
@@ -264,6 +266,7 @@ public static class BuildParameters
         context.Information("ShouldRunPSScriptAnalyzer: {0}", BuildParameters.ShouldRunPSScriptAnalyzer);
         context.Information("ShouldStrongNameOutputAssemblies: {0}", BuildParameters.ShouldStrongNameOutputAssemblies);
         context.Information("ShouldStrongNameSignDependentAssemblies: {0}", BuildParameters.ShouldStrongNameSignDependentAssemblies);
+        context.Information("ShouldSubmitToVirusTotal: {0}", BuildParameters.ShouldSubmitToVirusTotal);
         context.Information("SolutionDirectoryPath: {0}", context.MakeAbsolute((DirectoryPath)SolutionDirectoryPath));
         context.Information("SolutionFilePath: {0}", context.MakeAbsolute((FilePath)SolutionFilePath));
         context.Information("SonarQubeId: {0}", BuildParameters.SonarQubeId);
@@ -304,6 +307,7 @@ public static class BuildParameters
         Func<List<ILMergeConfig>> getILMergeConfigs = null,
         Func<List<PSScriptAnalyzerSettings>> getPSScriptAnalyzerSettings = null,
         Func<FilePathCollection> getMsisToSign = null,
+        Func<FilePathCollection> getFilesToSubmitToVirusTotal = null,
         Func<FilePathCollection> getProjectsToPack = null,
         Func<FilePathCollection> getScriptsToVerify = null,
         Func<FilePathCollection> getScriptsToSign = null,
@@ -376,6 +380,7 @@ public static class BuildParameters
         bool shouldRunPSScriptAnalyzer = true,
         bool shouldStrongNameOutputAssemblies = true,
         bool shouldStrongNameSignDependentAssemblies = true,
+        bool shouldSubmitToVirusTotal = true,
         Func<BuildVersion, object[]> slackMessageArguments = null,
         DirectoryPath solutionDirectoryPath = null,
         FilePath solutionFilePath = null,
@@ -438,6 +443,7 @@ public static class BuildParameters
         GetILMergeConfigs = getILMergeConfigs;
         GetPSScriptAnalyzerSettings = getPSScriptAnalyzerSettings;
         GetMsisToSign = getMsisToSign;
+        GetFilesToSubmitToVirusTotal = getFilesToSubmitToVirusTotal;
         GetProjectsToPack = getProjectsToPack;
         GetScriptsToVerify = getScriptsToVerify;
         GetScriptsToSign = getScriptsToSign;
@@ -756,6 +762,13 @@ public static class BuildParameters
         if (context.HasArgument("shouldStrongNameSignDependentAssemblies"))
         {
             ShouldStrongNameSignDependentAssemblies = context.Argument<bool>("shouldStrongNameSignDependentAssemblies");
+        }
+
+        ShouldSubmitToVirusTotal = shouldSubmitToVirusTotal;
+
+        if (context.HasArgument("shouldSubmitToVirusTotal"))
+        {
+            ShouldSubmitToVirusTotal = context.Argument<bool>("shouldSubmitToVirusTotal");
         }
 
         SlackMessageArguments = slackMessageArguments ?? _defaultNotificationArguments;

--- a/Chocolatey.Cake.Recipe/Content/tasks.cake
+++ b/Chocolatey.Cake.Recipe/Content/tasks.cake
@@ -100,6 +100,9 @@ public class BuildTasks
     // ILMerge Tasks
     public CakeTaskBuilder ILMergeTask { get; set; }
 
+    // VirusTotal Tasks
+    public CakeTaskBuilder SubmitToVirusTotalTask { get; set; }
+
     // Notification Tasks
     public CakeTaskBuilder SendNotificationsTask { get; set; }
 }

--- a/Chocolatey.Cake.Recipe/Content/toolsettings.cake
+++ b/Chocolatey.Cake.Recipe/Content/toolsettings.cake
@@ -48,6 +48,7 @@ public static class ToolSettings
     public static string TestCoverageExcludeByAttribute { get; private set; }
     public static string TestCoverageExcludeByFile { get; private set; }
     public static string TestCoverageFilter { get; private set; }
+    public static string VirusTotalTool { get; private set; }
     public static string WixTool { get; private set; }
     public static string XUnitTool { get; private set; }
 
@@ -69,6 +70,7 @@ public static class ToolSettings
         string reSharperTools = "#tool nuget:?package=JetBrains.ReSharper.CommandLineTools&version=2017.2.0",
         string sonarQubeTool = "#tool nuget:?package=MSBuild.SonarQube.Runner.Tool&version=4.8.0",
         string strongNameSignerTool = "#tool nuget:?package=Brutal.Dev.StrongNameSigner&version=2.6.0",
+        string virusTotalTool = "#tool choco:?package=vt-cli&version=1.3.0",
         string wixTool = "#tool nuget:?package=WiX&version=3.11.2",
         string xunitTool = "#tool nuget:?package=xunit.runner.console&version=2.4.1"
     )
@@ -90,6 +92,7 @@ public static class ToolSettings
         ReSharperTools = reSharperTools;
         SonarQubeTool = sonarQubeTool;
         StrongNameSignerTool = strongNameSignerTool;
+        VirusTotalTool = virusTotalTool;
         WixTool = wixTool;
         XUnitTool = xunitTool;
     }

--- a/Chocolatey.Cake.Recipe/Content/virustotal.cake
+++ b/Chocolatey.Cake.Recipe/Content/virustotal.cake
@@ -1,0 +1,130 @@
+// Copyright © 2022 Chocolatey Software, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+BuildParameters.Tasks.SubmitToVirusTotalTask = Task("Submit-To-VirusTotal")
+    .WithCriteria(() => BuildParameters.BuildAgentOperatingSystem == PlatformFamily.Windows, "Skipping due to not running on Windows")
+    .WithCriteria(() => BuildParameters.ShouldSubmitToVirusTotal, "Skipping since submission to VirusTotal has been disabled")
+    .WithCriteria(() => BuildParameters.IsTagged || string.Equals(BuildParameters.Target, "Submit-To-VirusTotal", StringComparison.OrdinalIgnoreCase), "Skipping because current commit is not tagged, and target name is not Submit-To-VirusTotal")
+    .Does(() =>
+{
+    if (BuildParameters.GetFilesToSubmitToVirusTotal == null)
+    {
+        Information("There are no files defined to be submitted to VirusTotal.");
+        return;
+    }
+
+    var filesToSubmit = BuildParameters.GetFilesToSubmitToVirusTotal();
+
+    if (filesToSubmit == null || !filesToSubmit.Any())
+    {
+        Information("There are no files defined to be submitted to VirusTotal.");
+        return;
+    }
+
+    var virusTotalCredentials = VirusTotalCredentials.FetchCredentials(Context);
+
+    if (string.IsNullOrWhiteSpace(virusTotalCredentials.ApiKey))
+    {
+        Warning("Unable to submit files to VirusTotal as no API Key has been provided. This can be set using the {0} environment variable.", Environment.VirusTotalApiKeyVariable);
+        return;
+    }
+
+    // Only install the vt-cli tool once there are actually files to submit and an API Key to
+    // submit them with
+    RequireTool(ToolSettings.VirusTotalTool, () =>
+    {
+        // There isn't a Cake Addin for vt-cli, so resolve the shimmed
+        // executable and drive it using the built in process aliases.
+        var vtToolLocation = Context.Tools.Resolve("vt.exe");
+
+        if (vtToolLocation == null)
+        {
+            Warning("Couldn't resolve the vt.exe tool, so unable to submit files to VirusTotal.");
+            return;
+        }
+
+        Information("Using vt-cli from: {0}", vtToolLocation);
+
+        // Guard against an incorrect API Key by making a lightweight, authenticated call
+        // (which uploads nothing) before submitting any files. Without this, an invalid key
+        // would upload every file, only to have each individual submission rejected.
+        Information("Verifying the VirusTotal API Key...");
+
+        IEnumerable<string> apiKeyCheckOutput;
+        IEnumerable<string> apiKeyCheckError;
+        var apiKeyCheckExitCode = StartProcess(vtToolLocation, new ProcessSettings {
+            Arguments = new ProcessArgumentBuilder().Append("meta"),
+            EnvironmentVariables = new Dictionary<string, string>
+            {
+                { "VTCLI_APIKEY", virusTotalCredentials.ApiKey }
+            },
+            RedirectStandardOutput = true,
+            RedirectStandardError = true
+        }, out apiKeyCheckOutput, out apiKeyCheckError);
+
+        if (apiKeyCheckExitCode != 0)
+        {
+            var apiKeyCheckErrorText = string.Join(System.Environment.NewLine, apiKeyCheckError ?? Enumerable.Empty<string>());
+
+            if (apiKeyCheckErrorText.IndexOf("Wrong API key", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                throw new Exception(string.Format("Unable to submit files to VirusTotal because the provided API Key was rejected. Verify the value of the {0} environment variable.", Environment.VirusTotalApiKeyVariable));
+            }
+
+            throw new Exception(string.Format("Unable to submit files to VirusTotal because VirusTotal could not be reached (vt exit code {0}). {1}", apiKeyCheckExitCode, apiKeyCheckErrorText).Trim());
+        }
+
+        var failures = new List<string>();
+
+        foreach (var fileToSubmit in filesToSubmit)
+        {
+            if (!FileExists(fileToSubmit))
+            {
+                Warning("The file expected ({0}) was not found for submission to VirusTotal.", fileToSubmit);
+                continue;
+            }
+
+            Information("Submitting '{0}' to VirusTotal...", fileToSubmit);
+
+            var exitCode = StartProcess(vtToolLocation, new ProcessSettings {
+                Arguments = new ProcessArgumentBuilder()
+                    .Append("scan")
+                    .Append("file")
+                    .AppendQuoted(MakeAbsolute(fileToSubmit).FullPath),
+                EnvironmentVariables = new Dictionary<string, string>
+                {
+                    { "VTCLI_APIKEY", virusTotalCredentials.ApiKey }
+                }
+            });
+
+            if (exitCode != 0)
+            {
+                Warning("Submission of '{0}' to VirusTotal returned a non-zero exit code ({1}).", fileToSubmit, exitCode);
+                failures.Add(fileToSubmit.GetFilename().ToString());
+            }
+        }
+
+        if (failures.Count != 0)
+        {
+            throw new Exception(string.Format("Failed to submit the following files to VirusTotal: {0}", string.Join(", ", failures)));
+        }
+    });
+})
+.OnError(exception =>
+{
+    Error(exception.Message);
+    Information("Submit-To-VirusTotal Task failed, but continuing with next Task...");
+    publishingError = true;
+});


### PR DESCRIPTION
## Description Of Changes

When publishing Chocolatey packages, the artifacts have to be submitted to VirusTotal, and scanned, before they can be approved.  Doing this as a separate step after the build means waiting for the scanning to complete before the approval process can start.

By submitting the files during the tagged build, the scanning happens in parallel with the rest of the release process, which should shorten the overall time taken to get a release approved.

Following the same approach as GetMsisToSign, each repository controls what is submitted by providing a getFilesToSubmitToVirusTotal function in its recipe.cake file.  When nothing is provided, the task does nothing.

Submission is done using the vt-cli Chocolatey package.  There is no Cake Addin for this tool, so it is executed using the built in Process Aliases.  The tool is installed using the RequireTool method, so that it is only installed when there are actually files to submit.

The API Key is collected from the VIRUSTOTAL_API_KEY environment variable, in the same way as the other credentials.  It is passed to the tool using the VTCLI_APIKEY environment variable rather than the --apikey argument, so that it is kept out of the command line and the build logs.

Before anything is uploaded, the API Key is verified using a lightweight call which uploads nothing.  Without this, an incorrect key would result in every file being uploaded, only to have each submission rejected.  An invalid key is reported differently from being unable to reach VirusTotal, so that the cause of the failure is clear.

The task only runs during tagged builds, with an exception for when it is explicitly named as the target, so that it can be run locally when required.  As with the publishing tasks, a failure is reported and the build continues, with the error being raised at the end of the CI task.

NOTE: Cake.Chocolatey.Module has been added to modules.cake, so that the "#tool choco:" directive can be used.  A module has to exist on disk before Cake runs, so unlike a tool it cannot be installed on demand.  Version 0.3.0 is used deliberately, as later versions no longer expose the module metadata that Cake looks for, and so never register the "choco" scheme.  As a result, consuming repositories need SkipVerification=true in the [Settings] section of their cake.config.

## Motivation and Context

We want to speed up the overall publishing time of Chocolatey Products

## Testing

1. Run `build.bat` for the chocolatey/choco repository on your machine
2. Clone the PR locally onto your VM
3. Copy the files from the Content folder of Chocolatey.Cake.Recipe into the `tools\Chocolatey.Cake.Recipe.0.32.0\Content` folder for chocolatey/choco
4. Run `build.bat --target=clean` just to verify that everything still compiles correctly
5. Run `build.bat` to get a complete build, including all the generated artifacts
6. Add the following into the recipe.cake file in chocolatey/choco

```
Func<FilePathCollection> getFilesToSubmitToVirusTotal = () =>
{
    // Rather than listing each binary individually, pick up every binary which ships inside the
    // Chocolatey package, along with the package itself. This means that anything added to the
    // package in future is submitted automatically, and this list cannot silently drift out of
    // step with the actual contents of the package.
    var filesToSubmit = GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/tools/chocolateyInstall/**/*.{exe|dll}")
                    + GetFiles(BuildParameters.Paths.Directories.ChocolateyPackages + "/**/chocolatey.*.nupkg");

    Information("The following files have been selected to be submitted to VirusTotal...");
    foreach (var fileToSubmit in filesToSubmit)
    {
        Information(fileToSubmit.FullPath);
    }

    return filesToSubmit;
};
```

Also, add the following:

```
getFilesToSubmitToVirusTotal: getFilesToSubmitToVirusTotal,
```

after the `getMsisToSign: getMsisToSign,` line

7. Run ` .\build.bat --target=Submit-To-VirusTotal --exclusive `
8. Verify that the list of files that "would" have been sent matches to what you expect to be submitted
9. Verify that it didn't actually submit anything, due to missing API Key
11. Enter an invalid API Key and ensure that it first installs the vt-cli package, and then fails gracefully

NOTE: We are not going to actually submit anything to VirusTotal for this test, but rather ensure that files "would" be submitted, when required.

If you wanted to provide a valid API Key, to prove things work as expected, can I suggest that you shorten the list of files to be something like:

```
var filesToSubmit = GetFiles(BuildParameters.Paths.Directories.ChocolateyNuspecDirectory + "/tools/chocolateyInstall/tools/**/*.{exe|dll}");;
```

Which should only submit 4 files

### Operating Systems Testing

* Dev VM4

## Change Types Made

* [ ] Bug fix (non-breaking change).
* [x] Feature / Enhancement (non-breaking change).
* [ ] Breaking change (fix or feature that could cause existing functionality to change).
* [ ] Documentation changes.
* [ ] PowerShell code changes.

## Change Checklist

* [ ] Requires a change to the documentation.
* [ ] Documentation has been updated.
* [ ] Tests to cover my changes, have been added.
* [ ] All new and existing tests passed?
* [ ] PowerShell code changes: PowerShell v3 compatibility checked?
* [ ] All items are complete on the [Definition of Done](https://github.com/chocolatey/home/blob/main/definition-of-done.md).

## Related Issue

Fixes #298 